### PR TITLE
Minimum viable Thrift message envelope support

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -114,3 +114,23 @@ module.exports.InvalidEnumerationValueError = TypedError({
     enumName: null,
     value: null
 });
+
+// Thrift Message Envelope
+
+module.exports.UnrecognizedMessageEnvelopeVersion = TypedError({
+    type: 'thrift-unrecognized-message-envelope-version',
+    message: 'unrecognized Thrift message envelope version: {version}',
+    version: null
+});
+
+module.exports.UnrecognizedMessageEnvelopeType = TypedError({
+    type: 'thrift-unrecognized-message-envelope-type',
+    message: 'unrecognized Thrift message envelope type: {value}',
+    value: null
+});
+
+module.exports.InvalidMessageEnvelopeTypeName = TypedError({
+    type: 'thrift-invalid-message-envelope-type-name',
+    message: 'invalid Thrift message envelope type name: {name}',
+    name: null
+});

--- a/message.js
+++ b/message.js
@@ -1,0 +1,264 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+// reverse engineered TBinaryProtocol message envelope spec
+// http://slackhappy.github.io/thriftfiddle/tbinaryspec.html
+
+var RW = require('./rw');
+var util = require('util');
+var errors = require('./errors');
+
+var types = {
+    CALL: 1,
+    REPLY: 2,
+    EXCEPTION: 3,
+    ONEWAY: 4
+};
+
+// <-> inverse
+
+var typeNames = {
+    1: 'CALL',
+    2: 'REPLY',
+    3: 'EXCEPTION',
+    4: 'ONEWAY'
+};
+
+var EMPTY_OBJECT = {};
+
+function Message(message) {
+    message = message || EMPTY_OBJECT;
+    this.id = message.id;
+    this.name = message.name;
+    this.body = message.body;
+    this.type = message.type;
+    this.version = message.version || 0; // >0 implies strict
+}
+
+function MessageRW(body) {
+    this.body = body;
+    RW.call(this);
+}
+util.inherits(MessageRW, RW);
+
+MessageRW.prototype.poolByteLength = function poolByteLength(result, message) {
+    // header
+    var length = message.name.length;
+    // names must be half-ascii, so ucs2 length === byte length
+    if (message.version > 0) { // strict
+        // version:2 type:2 name~4 id:4
+        length += 12;
+    } else { // legacy non-strict message header
+        // name~4 type:1 id:4
+        length += 9;
+    }
+
+    // body
+    result = this.body.poolByteLength(result, message.body);
+    if (result.err) {
+        return result;
+    }
+    length += result.length;
+
+    return result.reset(null, length);
+};
+
+MessageRW.prototype.poolWriteInto = function poolWriteInto(result, message, buffer, offset) {
+    if (message.version > 0) {
+        result = this.poolStrictWriteInto(result, message, buffer, offset);
+    } else {
+        result = this.poolLegacyWriteInto(result, message, buffer, offset);
+    }
+    if (result.err) {
+        return result;
+    }
+    offset = result.offset;
+
+    // write body
+    return this.body.poolWriteInto(result, message.body, buffer, offset);
+};
+
+MessageRW.prototype.poolStrictWriteInto = function poolStrictWriteInto(result, message, buffer, offset) {
+    // version:2 type:2 name~4 id:4
+
+    // version:2 (with MSB set)
+    buffer.writeUInt16BE(message.version | 0x8000, offset);
+    offset += 2;
+
+    // type:2
+    var type = types[message.type];
+    if (type == null) {
+        return result.reset(new errors.InvalidMessageEnvelopeTypeName({
+            name: message.type
+        }));
+    }
+    buffer.writeUInt16BE(type, offset);
+    offset += 2;
+
+    // name.length:4
+    buffer.writeUInt32BE(message.name.length, offset);
+    offset += 4;
+
+    // name:name.length
+    buffer.write(message.name, offset, 'ascii');
+    offset += message.name.length;
+
+    // id:4
+    buffer.writeUInt32BE(message.id, offset);
+    offset += 4;
+
+    return result.reset(null, offset);
+};
+
+MessageRW.prototype.poolLegacyWriteInto = function poolLegacyWriteInto(result, message, buffer, offset) {
+    // name~4 type:1 id:4
+
+    // name.length:4
+    buffer.writeUInt32BE(message.name.length, offset, true);
+    offset += 4;
+
+    // name:name.length
+    buffer.write(message.name, offset, 'ascii');
+    offset += message.name.length;
+
+    // type:1
+    var type = types[message.type];
+    if (type == null) {
+        return result.reset(new errors.InvalidMessageEnvelopeTypeName({
+            name: message.type
+        }));
+    }
+    buffer.writeUInt8(type, offset);
+    offset += 1;
+
+    // id:4
+    buffer.writeUInt32BE(message.id, offset, true);
+    offset += 4;
+
+    return result.reset(null, offset);
+};
+
+MessageRW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
+    var msb = buffer.readInt8(offset, true);
+    if (msb < 0) {
+        result = this.poolStrictReadFrom(result, buffer, offset);
+    } else {
+        result = this.poolLegacyReadFrom(result, buffer, offset);
+    }
+    if (result.err) {
+        return result;
+    }
+    var message = result.value;
+    offset = result.offset;
+
+    if (message.type === 'EXCEPTION') {
+        // TODO parse body as exception struct
+        return result.reset(new Error('Thrift exception'));
+    }
+
+    // body
+    result = this.body.poolReadFrom(result, buffer, offset);
+    if (result.err) {
+        return result;
+    }
+    message.body = result.value;
+    offset = result.offset;
+
+    return result.reset(null, offset, message);
+};
+
+MessageRW.prototype.poolStrictReadFrom = function poolStrictReadFrom(result, buffer, offset) {
+    // the first two bytes might be "flag" and "version", or just "version"
+    // with the MSB flipped to make strict distinguishable.
+    // The type only needs the lesser byte of the available two.
+    // version:2 type:2 name~4 id:4
+
+    var message = new Message();
+    message.version = buffer.readUInt16BE(offset, true) & ~0x8000; // mask out MSB
+    offset += 2;
+
+    if (message.version !== 1) {
+        return result.reset(new errors.UnrecognizedMessageEnvelopeVersion({
+            version: message.version
+        }));
+    }
+
+    // type:2
+    var type = buffer.readUInt16BE(offset, true) & 0xFF;
+    offset += 2;
+
+    message.type = typeNames[type];
+    if (message.type == null) {
+        return result.reset(new errors.UnrecognizedMessageEnvelopeType({
+            value: type
+        }));
+    }
+
+    // name.length:4
+    var length = buffer.readUInt32BE(offset, true);
+    offset += 4;
+
+    // name:name.length
+    message.name = buffer.toString('ascii', offset, offset + length, true);
+    offset += length;
+
+    // id:4
+    message.id = buffer.readUInt32BE(offset, true);
+    offset += 4;
+
+    return result.reset(null, offset, message);
+};
+
+MessageRW.prototype.poolLegacyReadFrom = function poolLegacyReadFrom(result, buffer, offset) {
+    // name~4 type:1 id:4
+    var message = new Message();
+
+    // name.length
+    var length = buffer.readUInt32BE(offset, true);
+    offset += 4;
+
+    // name:name.length
+    message.name = buffer.toString('ascii', offset, offset + length, true);
+    offset += length;
+
+    // type:2
+    var type = buffer.readUInt8(offset, true);
+    offset += 1;
+
+    // id:4
+    message.id = buffer.readUInt32BE(offset, true);
+    offset += 4;
+
+    message.type = typeNames[type];
+    if (message.type == null) {
+        return result.reset(new errors.UnrecognizedMessageEnvelopeType({
+            value: type
+        }));
+    }
+
+    return result.reset(null, offset, message);
+};
+
+module.exports.Message = Message;
+module.exports.MessageRW = MessageRW;
+module.exports.types = types;
+module.exports.typeNames = typeNames;

--- a/service.js
+++ b/service.js
@@ -21,6 +21,8 @@
 'use strict';
 
 var ast = require('./ast');
+var Message = require('./message').Message;
+var MessageRW = require('./message').MessageRW;
 
 function ThriftFunction(args) {
     this.name = args.name;
@@ -70,6 +72,24 @@ ThriftFunction.prototype.link = function link(model) {
 
     this.Arguments = this.args.Constructor;
     this.Result = this.result.Constructor;
+
+    // TODO cover oneway, if we ever have use for it
+    // istanbul ignore next
+    var type = this.oneway ? 'ONEWAY' : 'CALL';
+    this.ArgumentsMessage = this.makeMessageConstructor(this.name, type);
+    this.ResultMessage = this.makeMessageConstructor(this.name, 'RESULT');
+
+    this.argumentsMessageRW = new MessageRW(this.args.rw);
+    this.resultMessageRW = new MessageRW(this.result.rw);
+};
+
+ThriftFunction.prototype.makeMessageConstructor = function makeMessageConstructor(name, type) {
+    function FunctionMessage(message) {
+        Message.call(this, message);
+        this.name = name;
+        this.type = type;
+    }
+    return FunctionMessage;
 };
 
 function ThriftService(args) {

--- a/test/index.js
+++ b/test/index.js
@@ -55,3 +55,4 @@ require('./include.js');
 require('./type-mismatch');
 require('./lcp');
 require('./idls');
+require('./message');

--- a/test/message.js
+++ b/test/message.js
@@ -1,0 +1,302 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* global Buffer */
+/* eslint max-len:[0, 120] */
+'use strict';
+
+var test = require('tape');
+var path = require('path');
+var Thrift = require('../thrift').Thrift;
+
+var thrift = new Thrift({
+    entryPoint: path.join(__dirname, 'thrift.thrift'),
+    allowFilesystemAccess: true
+});
+
+test('round-trip a non-strict message', function t(assert) {
+
+    var message = new thrift.Service.foo.ArgumentsMessage({
+        id: 0,
+        body: new thrift.Service.foo.Arguments({
+            bar: new thrift.Struct({
+                number: 10
+            })
+        })
+    });
+
+    var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
+    var buffer = new Buffer(result.length);
+
+    var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
+
+    var expectedBuffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f, // name:name.length
+        0x01, // type:1 = CALL
+        0x00, 0x00, 0x00, 0x00, // id:4
+        // body
+        0x0c, // struct
+        0x00, 0x01, // field 1
+        0x08, // i32
+        0x00, 0x01, // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00, // end of foo
+        0x00 // end of result
+    ]);
+    assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
+
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+
+    assert.deepEqual(result.value, message, 'read correctly');
+
+    assert.end();
+});
+
+test('round-trip a non-strict message', function t(assert) {
+    thrift = new Thrift({
+        entryPoint: path.join(__dirname, 'thrift.thrift'),
+        allowFilesystemAccess: true
+    });
+
+    var message = new thrift.Service.foo.ArgumentsMessage({
+        version: 1,
+        id: 0,
+        body: new thrift.Service.foo.Arguments({
+            bar: new thrift.Struct({
+                number: 10
+            })
+        })
+    });
+
+    var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
+    var buffer = new Buffer(result.length);
+    var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
+
+    var expectedBuffer = new Buffer([
+        0x80, // strict
+        0x01, // version = 1
+        0x00, // shrug
+        0x01, // type = CALL
+        0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
+        0x66, 0x6f, 0x6f, // name:name.length = 'foo'
+        0x00, 0x00, 0x00, 0x00, // id:4 = 0
+        // body
+        0x0c, // struct
+        0x00, 0x01, // field 1
+        0x08, // i32
+        0x00, 0x01, // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00, // end of foo
+        0x00 // end of result
+    ]);
+    assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
+
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+
+    assert.deepEqual(result.value, message, 'read correctly');
+
+    assert.end();
+});
+
+test('read unexpected version error', function t(assert) {
+    var buffer = new Buffer([
+        0x80, // strict
+        0x02, // version = 2 XXX BUT WHAT IS GOING ON WITH VERSION 2!?
+        0x00, // shrug
+        0x01, // type = CALL
+        0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
+        0x66, 0x6f, 0x6f, // name:name.length = 'foo'
+        0x00, 0x00, 0x00, 0x00, // id:4 = 0
+        // body
+        0x0c, // struct
+        0x00, 0x01, // field 1
+        0x08, // i32
+        0x00, 0x01, // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00, // end of foo
+        0x00 // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'unrecognized Thrift message envelope version: 2',
+        'expected error message');
+    assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-version',
+        'expected error typed');
+    assert.end();
+});
+
+test('read unexpected version error for undefined bits of strict', function t(assert) {
+    var buffer = new Buffer([
+        0x81, // strict XXX BUT WHAT IS GOING ON WITH THIS LOW BIT!?
+        0x01, // version = 1
+        0x00, // shrug
+        0x01, // type = CALL
+        0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
+        0x66, 0x6f, 0x6f, // name:name.length = 'foo'
+        0x00, 0x00, 0x00, 0x00, // id:4 = 0
+        // body
+        0x0c, // struct
+        0x00, 0x01, // field 1
+        0x08, // i32
+        0x00, 0x01, // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00, // end of foo
+        0x00 // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'unrecognized Thrift message envelope version: 257',
+        'expected error message');
+    assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-version',
+        'expected error typed');
+    assert.end();
+});
+
+test('read unrecognized message type error (strict)', function t(assert) {
+    var buffer = new Buffer([
+        0x80, // strict
+        0x01, // version = 1
+        0x00, // shrug
+        0xff, // type = XXX WAT!?
+        0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
+        0x66, 0x6f, 0x6f, // name:name.length = 'foo'
+        0x00, 0x00, 0x00, 0x00, // id:4 = 0
+        // body
+        0x0c, // struct
+        0x00, 0x01, // field 1
+        0x08, // i32
+        0x00, 0x01, // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00, // end of foo
+        0x00 // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'unrecognized Thrift message envelope type: 255',
+        'expected error message');
+    assert.equal(result.err.value, 255,
+        'expected error value');
+    assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-type',
+        'expected error type');
+    assert.end();
+});
+
+test('read unrecognized message type error (legacy)', function t(assert) {
+    var buffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f, // name:name.length
+        0xff, // type:1 = XXX WAT!?
+        0x00, 0x00, 0x00, 0x00, // id:4
+        // body
+        0x0c, // struct
+        0x00, 0x01, // field 1
+        0x08, // i32
+        0x00, 0x01, // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00, // end of foo
+        0x00 // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'unrecognized Thrift message envelope type: 255',
+        'expected error message');
+    assert.equal(result.err.value, 255,
+        'expected error value');
+    assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-type',
+        'expected error type');
+    assert.end();
+});
+
+test('read invalid message body error', function t(assert) {
+    var buffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f, // name:name.length
+        0x01, // type:1 = CALL
+        0x00, 0x00, 0x00, 0x00, // id:4
+        // body
+        0x00, // struct
+        0x00, 0x02, // field 1 // XXX there is no field 2
+        0x08, // i32
+        0x00, 0x01, // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00, // end of foo
+        0x00 // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'missing required field "bar" with id 1 on foo_args',
+        'expected message');
+    assert.end();
+});
+
+test('read exception', function t(assert) {
+    var buffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f, // name:name.length
+        0x03, // type:3 = EXCEPTION
+        0x00, 0x00, 0x00, 0x00, // id:4
+        // TODO provide an exception body to read
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    // TODO read exception message and type off the wire
+    assert.equal(result.err.message, 'Thrift exception',
+        'expected message');
+    assert.end();
+});
+
+test('write invalid message type (legacy)', function t(assert) {
+    var buffer = new Buffer(255);
+    var message = {
+        name: 'foo',
+        type: 'BORK',
+        version: 0
+    };
+    var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
+    assert.equal(result.err.message, 'invalid Thrift message envelope type name: BORK',
+        'expected message');
+    assert.end();
+});
+
+test('write invalid message type (strict)', function t(assert) {
+    var buffer = new Buffer(255);
+    var message = {
+        name: 'foo',
+        type: 'BORK',
+        version: 1
+    };
+    var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
+    assert.equal(result.err.message, 'invalid Thrift message envelope type name: BORK',
+        'expected message');
+    assert.end();
+});
+
+test('measure byte length for invalid body', function t(assert) {
+    var buffer = new Buffer(255);
+    var message = {
+        name: 'foo',
+        type: 'BORK',
+        version: 1,
+        body: {
+            bar: {
+                number: null
+            }
+        }
+    };
+    var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
+    assert.equal(result.err.message, 'missing required field "number" with id 1 on Struct',
+        'expected message');
+    assert.end();
+});

--- a/test/thrift.thrift
+++ b/test/thrift.thrift
@@ -1,4 +1,3 @@
-
 struct Struct {
     1: required i32 number
 }

--- a/thrift.js
+++ b/thrift.js
@@ -49,6 +49,8 @@ var ThriftMap = require('./map').ThriftMap;
 var ThriftConst = require('./const').ThriftConst;
 var ThriftTypedef = require('./typedef').ThriftTypedef;
 
+var Message = require('./message').Message;
+
 var validThriftIdentifierRE = /^[a-zA-Z_][a-zA-Z0-9_\.]+$/;
 
 function Thrift(options) {
@@ -132,6 +134,8 @@ function Thrift(options) {
 }
 
 Thrift.prototype.models = 'module';
+
+Thrift.prototype.Message = Message;
 
 Thrift.prototype.getType = function getType(name) {
     return this.getTypeResult(name).toValue();


### PR DESCRIPTION
This adds the argumentsMessageRW and resultMessageRW to the thrift.{Service}.{function} addressable model objects, for all types regardless of whether they are used.