### PR TITLE
Implement ThriftMessageEnvelopeException RW

### DIFF
--- a/service.js
+++ b/service.js
@@ -77,17 +77,17 @@ ThriftFunction.prototype.link = function link(model) {
     // istanbul ignore next
     var type = this.oneway ? 'ONEWAY' : 'CALL';
     this.ArgumentsMessage = this.makeMessageConstructor(this.name, type);
-    this.ResultMessage = this.makeMessageConstructor(this.name, 'RESULT');
+    this.ResultMessage = this.makeMessageConstructor(this.name, 'REPLY');
 
-    this.argumentsMessageRW = new MessageRW(this.args.rw);
-    this.resultMessageRW = new MessageRW(this.result.rw);
+    this.argumentsMessageRW = new MessageRW(this.args.rw, model.exception.rw);
+    this.resultMessageRW = new MessageRW(this.result.rw, model.exception.rw);
 };
 
 ThriftFunction.prototype.makeMessageConstructor = function makeMessageConstructor(name, type) {
     function FunctionMessage(message) {
         Message.call(this, message);
-        this.name = name;
-        this.type = type;
+        this.name = message.name || name;
+        this.type = message.type || type;
     }
     return FunctionMessage;
 };

--- a/test/message.js
+++ b/test/message.js
@@ -49,17 +49,17 @@ test('round-trip a non-strict message', function t(assert) {
 
     var expectedBuffer = new Buffer([
         0x00, 0x00, 0x00, 0x03, // name.length:4
-        0x66, 0x6f, 0x6f, // name:name.length
-        0x01, // type:1 = CALL
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0x01,                   // type:1 = CALL
         0x00, 0x00, 0x00, 0x00, // id:4
-        // body
-        0x0c, // struct
-        0x00, 0x01, // field 1
-        0x08, // i32
-        0x00, 0x01, // field 1
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
         0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-        0x00, // end of foo
-        0x00 // end of result
+        0x00,                   // end of foo
+        0x00                    // end of result
     ]);
     assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
 
@@ -86,21 +86,21 @@ test('round-trip a non-strict message', function t(assert) {
     var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
 
     var expectedBuffer = new Buffer([
-        0x80, // strict
-        0x01, // version = 1
-        0x00, // shrug
-        0x01, // type = CALL
+        0x80,                   // strict
+        0x01,                   // version = 1
+        0x00,                   // shrug
+        0x01,                   // type = CALL
         0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
-        0x66, 0x6f, 0x6f, // name:name.length = 'foo'
+        0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
         0x00, 0x00, 0x00, 0x00, // id:4 = 0
-        // body
-        0x0c, // struct
-        0x00, 0x01, // field 1
-        0x08, // i32
-        0x00, 0x01, // field 1
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
         0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-        0x00, // end of foo
-        0x00 // end of result
+        0x00,                   // end of foo
+        0x00                    // end of result
     ]);
     assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
 
@@ -111,23 +111,72 @@ test('round-trip a non-strict message', function t(assert) {
     assert.end();
 });
 
+test('round trip an exception (legacy)', function t(assert) {
+    // TODO exercise version=1
+    var message = new thrift.Service.foo.ResultMessage({
+        id: 2,
+        type: 'EXCEPTION',
+        body: new thrift.exception.Constructor({
+            message: 'Unknown method',
+            type: 'UNKNOWN_METHOD'
+        })
+    });
+
+    var expectedBuffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f,       // name:name.length -- "foo"
+        0x03,                   // type:3 = EXCEPTION
+        0x00, 0x00, 0x00, 0x02, // id:4 -- 2
+                                // exception
+        0x0b,                   // typeid:1 -- 11 -- STRING
+        0x00, 0x01,             // fieldid:2 -- 1 -- message
+        0x00, 0x00, 0x00, 0x0e, // length
+        0x55, 0x6e, 0x6b, 0x6e,
+        0x6f, 0x77, 0x6e, 0x20,
+        0x6d, 0x65, 0x74, 0x68,
+        0x6f, 0x64,
+        0x08,                   // typeid:1 -- 8 -- i32
+        0x00, 0x02,             // fieldid:2 -- 2 -- type
+        0x00, 0x00, 0x00, 0x01, // type:4 -- 1 -- UNKNOWN_METHOD
+        0x00                    // end of struct
+    ]);
+
+    var result = thrift.Service.foo.resultMessageRW.byteLength(message);
+    assert.equal(result.length, expectedBuffer.length, 'measured correctly');
+
+    var buffer = new Buffer(result.length);
+    buffer.fill(0xCC);
+
+    var result = thrift.Service.foo.resultMessageRW.writeInto(message, buffer, 0);
+    if (result.err) return assert.end(result.err);
+
+    assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
+
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+
+    assert.deepEqual(result.err, message.body, 'produced proper error');
+    assert.deepEqual(result.value, message, 'read correctly');
+
+    assert.end();
+});
+
 test('read unexpected version error', function t(assert) {
     var buffer = new Buffer([
-        0x80, // strict
-        0x02, // version = 2 XXX BUT WHAT IS GOING ON WITH VERSION 2!?
-        0x00, // shrug
-        0x01, // type = CALL
+        0x80,                   // strict
+        0x02,                   // version = 2 XXX BUT WHAT IS GOING ON WITH VERSION 2!?
+        0x00,                   // shrug
+        0x01,                   // type = CALL
         0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
-        0x66, 0x6f, 0x6f, // name:name.length = 'foo'
+        0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
         0x00, 0x00, 0x00, 0x00, // id:4 = 0
-        // body
-        0x0c, // struct
-        0x00, 0x01, // field 1
-        0x08, // i32
-        0x00, 0x01, // field 1
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
         0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-        0x00, // end of foo
-        0x00 // end of result
+        0x00,                   // end of foo
+        0x00                    // end of result
     ]);
     var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
     assert.equal(result.err.message, 'unrecognized Thrift message envelope version: 2',
@@ -139,21 +188,21 @@ test('read unexpected version error', function t(assert) {
 
 test('read unexpected version error for undefined bits of strict', function t(assert) {
     var buffer = new Buffer([
-        0x81, // strict XXX BUT WHAT IS GOING ON WITH THIS LOW BIT!?
-        0x01, // version = 1
-        0x00, // shrug
-        0x01, // type = CALL
+        0x81,                   // strict XXX BUT WHAT IS GOING ON WITH THIS LOW BIT!?
+        0x01,                   // version = 1
+        0x00,                   // shrug
+        0x01,                   // type = CALL
         0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
-        0x66, 0x6f, 0x6f, // name:name.length = 'foo'
+        0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
         0x00, 0x00, 0x00, 0x00, // id:4 = 0
-        // body
-        0x0c, // struct
-        0x00, 0x01, // field 1
-        0x08, // i32
-        0x00, 0x01, // field 1
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
         0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-        0x00, // end of foo
-        0x00 // end of result
+        0x00,                   // end of foo
+        0x00                    // end of result
     ]);
     var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
     assert.equal(result.err.message, 'unrecognized Thrift message envelope version: 257',
@@ -165,21 +214,21 @@ test('read unexpected version error for undefined bits of strict', function t(as
 
 test('read unrecognized message type error (strict)', function t(assert) {
     var buffer = new Buffer([
-        0x80, // strict
-        0x01, // version = 1
-        0x00, // shrug
-        0xff, // type = XXX WAT!?
+        0x80,                   // strict
+        0x01,                   // version = 1
+        0x00,                   // shrug
+        0xff,                   // type = XXX WAT!?
         0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
-        0x66, 0x6f, 0x6f, // name:name.length = 'foo'
+        0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
         0x00, 0x00, 0x00, 0x00, // id:4 = 0
-        // body
-        0x0c, // struct
-        0x00, 0x01, // field 1
-        0x08, // i32
-        0x00, 0x01, // field 1
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
         0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-        0x00, // end of foo
-        0x00 // end of result
+        0x00,                   // end of foo
+        0x00                    // end of result
     ]);
     var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
     assert.equal(result.err.message, 'unrecognized Thrift message envelope type: 255',
@@ -194,17 +243,17 @@ test('read unrecognized message type error (strict)', function t(assert) {
 test('read unrecognized message type error (legacy)', function t(assert) {
     var buffer = new Buffer([
         0x00, 0x00, 0x00, 0x03, // name.length:4
-        0x66, 0x6f, 0x6f, // name:name.length
-        0xff, // type:1 = XXX WAT!?
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0xff,                   // type:1 = XXX WAT!?
         0x00, 0x00, 0x00, 0x00, // id:4
-        // body
-        0x0c, // struct
-        0x00, 0x01, // field 1
-        0x08, // i32
-        0x00, 0x01, // field 1
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
         0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-        0x00, // end of foo
-        0x00 // end of result
+        0x00,                   // end of foo
+        0x00                    // end of result
     ]);
     var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
     assert.equal(result.err.message, 'unrecognized Thrift message envelope type: 255',
@@ -219,17 +268,16 @@ test('read unrecognized message type error (legacy)', function t(assert) {
 test('read invalid message body error', function t(assert) {
     var buffer = new Buffer([
         0x00, 0x00, 0x00, 0x03, // name.length:4
-        0x66, 0x6f, 0x6f, // name:name.length
-        0x01, // type:1 = CALL
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0x01,                   // type:1 = CALL
         0x00, 0x00, 0x00, 0x00, // id:4
-        // body
-        0x00, // struct
-        0x00, 0x02, // field 1 // XXX there is no field 2
-        0x08, // i32
-        0x00, 0x01, // field 1
+                                // body
+        0x00, 0x02,             // field 1 -- XXX there is no field 2
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
         0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-        0x00, // end of foo
-        0x00 // end of result
+        0x00,                   // end of foo
+        0x00                    // end of result
     ]);
     var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
     assert.equal(result.err.message, 'missing required field "bar" with id 1 on foo_args',
@@ -240,15 +288,47 @@ test('read invalid message body error', function t(assert) {
 test('read exception', function t(assert) {
     var buffer = new Buffer([
         0x00, 0x00, 0x00, 0x03, // name.length:4
-        0x66, 0x6f, 0x6f, // name:name.length
-        0x03, // type:3 = EXCEPTION
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0x03,                   // type:3 = EXCEPTION
         0x00, 0x00, 0x00, 0x00, // id:4
-        // TODO provide an exception body to read
+                                // exception
+        0x0b,                   // typeid:1 -- 11 -- STRING
+        0x00, 0x01,             // fieldid:2 -- 1 -- message
+        0x00, 0x00, 0x00, 0x10, // length
+        0x55, 0x6e, 0x65, 0x78,
+        0x70, 0x65, 0x63, 0x74,
+        0x65, 0x64, 0x20, 0x65,
+        0x72, 0x72, 0x6f, 0x72, // "Unexpected error"
+        0x08,                   // typeid:1 -- 8 -- i32
+        0x00, 0x02,             // fieldid:2 -- 2 -- type
+        0x00, 0x00, 0x00, 0x00, // type:4 -- 0 -- UNKNOWN
+        0x00,                   // end of struct
     ]);
     var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-    // TODO read exception message and type off the wire
-    assert.equal(result.err.message, 'Thrift exception',
+    assert.equal(result.err.message, 'Unexpected error',
         'expected message');
+    assert.equal(result.err.type, 'UNKNOWN',
+        'expected message');
+    assert.end();
+});
+
+test('read invalid exception', function t(assert) {
+    var buffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0x03,                   // type:3 = EXCEPTION
+        0x00, 0x00, 0x00, 0x00, // id:4
+                                // exception
+        0x08,                   // typeid:1 -- 8, i32 XXX invalid
+        0x00, 0x01,             // fieldid:2 -- 1 -- message
+        // ...
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message,
+        'unexpected typeid 8 (I32) for field "message" with id 1 on ' +
+        'ThriftMessageEnvelopeException; expected 11 (STRING)',
+        'expected error'
+    );
     assert.end();
 });
 
@@ -292,6 +372,21 @@ test('measure byte length for invalid body', function t(assert) {
     };
     var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
     assert.equal(result.err.message, 'missing required field "number" with id 1 on Struct',
+        'expected message');
+    assert.end();
+});
+
+test('measure byte length for invalid exception', function t(assert) {
+    var buffer = new Buffer(255);
+    var message = {
+        name: 'foo',
+        type: 'EXCEPTION',
+        body: {
+            message: 10
+        }
+    };
+    var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
+    assert.equal(result.err.message, 'invalid argument, expected string, null, or undefined',
         'expected message');
     assert.end();
 });

--- a/thrift.js
+++ b/thrift.js
@@ -50,6 +50,8 @@ var ThriftConst = require('./const').ThriftConst;
 var ThriftTypedef = require('./typedef').ThriftTypedef;
 
 var Message = require('./message').Message;
+var messageExceptionDef = require('./message').exceptionDef;
+var messageExceptionTypesDef = require('./message').exceptionTypesDef;
 
 var validThriftIdentifierRE = /^[a-zA-Z_][a-zA-Z0-9_\.]+$/;
 
@@ -123,6 +125,8 @@ function Thrift(options) {
         this.idls[this.filename] = source;
     }
 
+    this.exception = null;
+
     // Separate compile/link passes permits forward references and cyclic
     // references.
     this.compile(source);
@@ -130,7 +134,6 @@ function Thrift(options) {
     if (!options.noLink) {
         this.link();
     }
-
 }
 
 Thrift.prototype.models = 'module';
@@ -194,6 +197,8 @@ Thrift.prototype.compile = function compile(source) {
     assert.equal(syntax.type, 'Program', 'expected a program');
     this._compile(syntax.headers);
     this._compile(syntax.definitions);
+    this.compileEnum(messageExceptionTypesDef);
+    this.exception = this.compileStruct(messageExceptionDef);
 };
 
 Thrift.prototype.define = function define(name, def, model) {
@@ -326,6 +331,8 @@ Thrift.prototype.link = function link() {
     for (var index = 0; index < names.length; index++) {
         this.models[names[index]].link(this);
     }
+
+    this.exception.link(this);
 
     return this;
 };


### PR DESCRIPTION
This is a bit ugly, but for now, this introduces a couple implicit types in every module for Thrift exceptions, so I can get at the RW object that Thrift generates. Adds tests to round trip exceptions and fail on malformed exception bodies on the wire.

r @abhinav 