### PR TITLE
Support serialization of a Thrift model through JSON for caching

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -3,6 +3,7 @@ instrumentation:
     excludes:
         - benchmarks/**
         - thrift-idl.js
+        - thrift2json.js
 check:
     global:
         statements: 100

--- a/ast.js
+++ b/ast.js
@@ -43,139 +43,140 @@
 
 module.exports.Program = Program;
 function Program(headers, definitions) {
+    this.type = 'Program';
     this.headers = headers;
     this.definitions = definitions;
 }
-Program.prototype.type = 'Program';
 
 module.exports.Identifier = Identifier;
 function Identifier(name, line, column) {
+    this.type = 'Identifier';
     this.name = name;
     this.line = line;
     this.column = column;
     this.as = null;
 }
-Identifier.prototype.type = 'Identifier';
 
 module.exports.Include = Include;
 function Include(id, namespace, line, column) {
+    this.type = 'Include';
     this.id = id;
     this.namespace = namespace;
     this.line = line;
     this.column = column;
 }
-Include.prototype.type = 'Include';
 
 module.exports.Namespace = Namespace;
 function Namespace(id, scope) {
+    this.type = 'Namespace';
     this.id = id;
     this.scope = scope;
 }
-Namespace.prototype.type = 'Namespace';
 
 module.exports.Typedef = Typedef;
 function Typedef(type, id, annotations) {
+    this.type = 'Typedef';
     this.valueType = type;
     this.id = id;
     this.annotations = annotations;
 }
-Typedef.prototype.type = 'Typedef';
 
 module.exports.BaseType = BaseType;
 function BaseType(type, annotations) {
+    this.type = 'BaseType';
     this.baseType = type;
     this.annotations = annotations;
 }
-BaseType.prototype.type = 'BaseType';
 
 module.exports.Enum = Enum;
 function Enum(id, definitions, annotations) {
+    this.type = 'Enum';
     this.id = id;
     this.definitions = definitions;
     this.annotations = annotations;
 }
-Enum.prototype.type = 'Enum';
 
 module.exports.EnumDefinition = EnumDefinition;
 function EnumDefinition(id, value, annotations) {
+    this.type = 'EnumDefinition';
+    this.fieldType = new BaseType('i32');
     this.id = id;
     this.value = value;
     this.annotations = annotations;
 }
-EnumDefinition.prototype.fieldType = new BaseType('i32');
-EnumDefinition.prototype.type = 'EnumDefinition';
 
 module.exports.Senum = Senum;
 function Senum(id, definitions, annotations) {
+    this.type = 'Senum';
     this.id = id;
     this.senumDefinitions = definitions;
     this.annotations = annotations;
 }
-Senum.prototype.type = 'Senum';
 
 module.exports.Const = Const;
 function Const(id, fieldType, value) {
+    this.type = 'Const';
     this.id = id;
     this.fieldType = fieldType;
     this.value = value;
 }
-Const.prototype.type = 'Const';
 
 module.exports.ConstList = ConstList;
 function ConstList(values) {
+    this.type = 'ConstList';
     this.values = values;
 }
-ConstList.prototype.type = 'ConstList';
 
 module.exports.ConstMap = ConstMap;
 function ConstMap(entries) {
+    this.type = 'ConstMap';
     this.entries = entries;
 }
-ConstMap.prototype.type = 'ConstMap';
 
 module.exports.ConstEntry = ConstEntry;
 function ConstEntry(key, value) {
+    this.type = 'ConstEntry';
     this.key = key;
     this.value = value;
 }
-ConstEntry.prototype.type = 'ConstEntry';
 
 module.exports.Struct = Struct;
 function Struct(id, fields, annotations) {
+    this.type = 'Struct';
     this.id = id;
     this.fields = fields;
     this.annotations = annotations;
     this.isArgument = false;
     this.isResult = false;
 }
-Struct.prototype.type = 'Struct';
 
 module.exports.Union = Union;
 function Union(id, fields) {
+    this.type = 'Union';
     this.id = id;
     this.fields = fields;
 }
-Union.prototype.type = 'Union';
 
 module.exports.Exception = Exception;
 function Exception(id, fields, annotations) {
+    this.type = 'Exception';
     this.id = id;
     this.fields = fields;
     this.annotations = annotations;
 }
-Exception.prototype.type = 'Exception';
 
 module.exports.Service = Service;
 function Service(id, functions, annotations, baseService) {
+    this.type = 'Service';
     this.id = id;
     this.functions = functions;
     this.annotations = annotations;
     this.baseService = baseService;
 }
-Service.prototype.type = 'Service';
 
 module.exports.FunctionDefinition = FunctionDefinition;
 function FunctionDefinition(id, fields, ft, _throws, annotations, oneway) {
+    this.type = 'Function';
     this.id = id;
     this.returns = ft;
     this.fields = fields;
@@ -184,10 +185,10 @@ function FunctionDefinition(id, fields, ft, _throws, annotations, oneway) {
     this.annotations = annotations;
     this.oneway = oneway;
 }
-FunctionDefinition.prototype.type = 'function';
 
 module.exports.Field = Field;
 function Field(id, ft, name, req, fv, annotations) {
+    this.type = 'Field';
     this.id = id;
     this.name = name;
     this.valueType = ft;
@@ -196,54 +197,52 @@ function Field(id, ft, name, req, fv, annotations) {
     this.defaultValue = fv;
     this.annotations = annotations;
 }
-Field.prototype.type = 'Field';
 
 module.exports.FieldIdentifier = FieldIdentifier;
 function FieldIdentifier(value, line, column) {
+    this.type = 'FieldIdentifier';
     this.value = value;
     this.line = line;
     this.column = column;
 }
-FieldIdentifier.prototype.type = 'FieldIdentifier';
 
 module.exports.MapType = MapType;
 function MapType(keyType, valueType, annotations) {
+    this.type = 'Map';
     this.keyType = keyType;
     this.valueType = valueType;
     this.annotations = annotations;
 }
-MapType.prototype.type = 'Map';
 
 module.exports.SetType = SetType;
 function SetType(valueType, annotations) {
+    this.type = 'Set';
     this.valueType = valueType;
     this.annotations = annotations;
 }
-SetType.prototype.type = 'Set';
 
 module.exports.ListType = ListType;
 function ListType(valueType, annotations) {
+    this.type = 'List';
     this.valueType = valueType;
     this.annotations = annotations;
 }
-ListType.prototype.type = 'List';
 
 module.exports.TypeAnnotation = TypeAnnotation;
 function TypeAnnotation(name, value) {
+    this.type = 'TypeAnnotation';
     this.name = name;
     this.value = value;
 }
-TypeAnnotation.prototype.type = 'TypeAnnotation';
 
 module.exports.Comment = Comment;
 function Comment(value) {
+    this.type = 'Comment';
     this.value = value;
 }
-Comment.prototype.type = 'Comment';
 
 module.exports.Literal = Literal;
 function Literal(value) {
+    this.type = 'Literal';
     this.value = value;
 }
-Literal.prototype.type = 'Literal';
-

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
       "url": "http://github.com/thriftrw/thriftrw-node/raw/master/LICENSE"
     }
   ],
+  "bin": {
+      "thrift2json": "./thrift2json.js"
+  },
   "scripts": {
     "add-licence": "uber-licence",
     "build-parser": "pegjs --allowed-start-rules Program --cache thrift-idl.pegjs && uber-licence --file thrift-idl.js > /dev/null",

--- a/test/asts.js
+++ b/test/asts.js
@@ -20,40 +20,30 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./double');
-require('./i8');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./map-entries');
-require('./thrift-idl');
-require('./map-object');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./struct-skip');
-require('./recursion');
-require('./exception');
-require('./union');
-require('./service');
-require('./thrift');
-require('./list');
-require('./set');
-require('./map');
-require('./typedef');
-require('./const');
-require('./default');
-require('./enum');
-require('./unrecognized-exception');
-require('./include.js');
-require('./type-mismatch');
-require('./lcp');
-require('./idls');
-require('./asts');
-require('./message');
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var Thrift = require('../thrift').Thrift;
+var IDL = require('./thrift-idl');
+
+test('can round trip a thrift file through sources', function t(assert) {
+
+    var thrift = new Thrift({
+        entryPoint: path.join(__dirname, 'include-cyclic-a.thrift'),
+        fs: fs,
+        allowFsAccess: true,
+        allowIncludeAlias: true
+    });
+
+    var json = thrift.toJSON();
+    var rethrift = new Thrift({
+        entryPoint: json.entryPoint,
+        asts: json.asts,
+        allowIncludeAlias: true
+    });
+
+    assert.deepEquals(Object.keys(rethrift.models), Object.keys(thrift.models), 'all models survive round trip');
+
+    assert.end();
+});
+

--- a/test/idls.js
+++ b/test/idls.js
@@ -24,6 +24,7 @@ var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var Thrift = require('../thrift').Thrift;
+var IDL = require('./thrift-idl');
 
 test('can round trip a thrift file through sources', function t(assert) {
 
@@ -45,4 +46,3 @@ test('can round trip a thrift file through sources', function t(assert) {
 
     assert.end();
 });
-

--- a/thrift.js
+++ b/thrift.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* eslint max-statements:[1, 40] */
+/* eslint max-statements:[1, 42] */
 'use strict';
 
 var assert = require('assert');
@@ -69,6 +69,8 @@ function Thrift(options) {
 
     // filename to source
     this.idls = options.idls || Object.create(null);
+    // filename to ast
+    this.asts = options.asts || Object.create(null);
     // filename to Thrift instance
     this.memo = options.memo || Object.create(null);
 
@@ -114,10 +116,11 @@ function Thrift(options) {
     this.dirname = path.dirname(this.filename);
     this.memo[this.filename] = this;
 
+    var ast = this.asts[options.entryPoint];
     var source = this.idls[options.entryPoint];
-    if (!source) {
+    if (!source && !ast) {
         /* eslint-disable max-len */
-        assert.ok(this.fs, this.filename + ': Thrift must be constructed with either a complete set of options.idls or options.fs access');
+        assert.ok(this.fs, this.filename + ': Thrift must be constructed with either a complete set of options.idls, options.asts, or options.fs access');
         assert.ok(this.filename, 'Thrift must be constructed with a options.entryPoint');
         /* eslint-enable max-len */
         this.filename = path.resolve(this.filename);
@@ -164,6 +167,18 @@ Thrift.prototype.getSources = function getSources() {
     return {entryPoint: entryPoint, idls: idls};
 };
 
+Thrift.prototype.toJSON = function toJSON() {
+    var filenames = Object.keys(this.idls);
+    var common = lcp.longestCommonPath(filenames);
+    var asts = {};
+    for (var index = 0; index < filenames.length; index++) {
+        var filename = filenames[index];
+        asts[filename.slice(common.length)] = this.asts[filename];
+    }
+    var entryPoint = this.filename.slice(common.length);
+    return {entryPoint: entryPoint, asts: asts};
+};
+
 Thrift.prototype.getServiceEndpoints = function getServiceEndpoints(target) {
     target = target || null;
     var services = Object.keys(this.services);
@@ -193,7 +208,11 @@ Thrift.prototype.baseTypes = {
 };
 
 Thrift.prototype.compile = function compile(source) {
-    var syntax = idl.parse(source);
+    var syntax = this.asts[this.filename];
+    if (!syntax) {
+        syntax = idl.parse(source);
+        this.asts[this.filename] = syntax;
+    }
     assert.equal(syntax.type, 'Program', 'expected a program');
     this._compile(syntax.headers);
     this._compile(syntax.definitions);
@@ -255,6 +274,7 @@ Thrift.prototype.compileInclude = function compileInclude(def) {
                 entryPoint: filename,
                 fs: this.fs,
                 idls: this.idls,
+                asts: this.asts,
                 memo: this.memo,
                 strict: this.strict,
                 allowIncludeAlias: true,

--- a/thrift2json.js
+++ b/thrift2json.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var Thrift = require('./thrift').Thrift;
+var fs = require('fs');
+var path = require('path');
+
+function main() {
+    try {
+        var thrift = new Thrift({
+            entryPoint: path.resolve(process.argv[2]),
+            allowFilesystemAccess: true
+        });
+        console.log(JSON.stringify(thrift.toJSON()));
+    } catch (error) {
+        console.log(error);
+        process.exit(-1);
+    }
+}
+
+if (require.main === module) {
+    main();
+}


### PR DESCRIPTION
Adds a thrift2json tool for converting Thrift IDL to a JSON AST. That JSON AST is accepted as options to construct a Thrift model, so you can bypass the IDL parser.

The Thrift AST may also be useful for caching between tcurls.

r @malandrew @abhinav 
cc @matt-esch