### PR TITLE
Unravel bufrw Series workaround

### DIFF
--- a/list.js
+++ b/list.js
@@ -106,10 +106,6 @@ ListRW.prototype.poolWriteInto = function poolWriteInto(destResult, list, buffer
 ListRW.prototype.poolReadFrom = function poolReadFrom(destResult, buffer, offset) {
     var valueType = this.valueType;
 
-    // The following ensures that bufrw does *not* reuse the prior result
-    // value, which previously made this function non-reentrant.
-    destResult.value = [0, 0];
-
     var t = this.headerRW.poolReadFrom(destResult, buffer, offset);
     // istanbul ignore if
     if (t.err) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "dependencies": {
-    "bufrw": "^1.2.0",
+    "bufrw": "^1.2.1",
     "error": "7.0.2",
     "long": "^2.4.0"
   },


### PR DESCRIPTION
This removes the work-around and retains the regression test, which still passes, having updated bufrw with the proper bufix for SeriesRW.

r @jcorbin @Raynos @abhinav 