### PR TITLE
Support numeric keys in maps

### DIFF
--- a/i16.js
+++ b/i16.js
@@ -21,13 +21,59 @@
 'use strict';
 
 var bufrw = require('bufrw');
+var ebufrw = require('bufrw/errors');
+var util = require('util');
 var TYPE = require('./TYPE');
+var errors = require('./errors');
 
-var I16RW = bufrw.Int16BE;
+function I16RW() {
+}
+
+util.inherits(I16RW, bufrw.Base);
+
+I16RW.prototype.name = 'i16';
+I16RW.prototype.width = 2;
+I16RW.prototype.min = -0x7fff - 1;
+I16RW.prototype.max = 0x7fff;
+
+I16RW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
+    var value = buffer.readInt16BE(offset, true);
+    return result.reset(null, offset + this.width, value);
+};
+
+I16RW.prototype.poolWriteInto = function poolWriteInto(result, value, buffer, offset) {
+    var coerced = +value;
+    if ((typeof value !== 'string' && typeof value !== 'number') || !isFinite(coerced)) {
+        return result.reset(new ebufrw.InvalidArgument({
+            expected: 'a number'
+        }));
+    }
+
+    var remain = buffer.length - offset;
+    // istanbul ignore if
+    if (remain < this.width) {
+        return bufrw.WriteResult.poolShortError(result, this.width, remain, offset);
+    }
+
+    if (value < this.min || value > this.max) {
+        return result.reset(new ebufrw.RangeError({
+            value: coerced,
+            min: this.min,
+            max: this.max
+        }));
+    }
+
+    buffer.writeInt16BE(coerced, offset, true);
+    return result.reset(null, offset + this.width);
+};
+
+I16RW.prototype.poolByteLength = function poolByteLength(result, value) {
+    return result.reset(null, this.width);
+};
 
 function ThriftI16() { }
 
-ThriftI16.prototype.rw = I16RW;
+ThriftI16.prototype.rw = new I16RW();
 ThriftI16.prototype.name = 'i16';
 ThriftI16.prototype.typeid = TYPE.I16;
 ThriftI16.prototype.surface = Number;

--- a/i8.js
+++ b/i8.js
@@ -21,13 +21,59 @@
 'use strict';
 
 var bufrw = require('bufrw');
+var ebufrw = require('bufrw/errors');
+var util = require('util');
 var TYPE = require('./TYPE');
+var errors = require('./errors');
 
-var I8RW = bufrw.Int8;
+function I8RW() {
+}
+
+util.inherits(I8RW, bufrw.Base);
+
+I8RW.prototype.name = 'i8';
+I8RW.prototype.width = 1;
+I8RW.prototype.min = -0x7f - 1;
+I8RW.prototype.max = 0x7f;
+
+I8RW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
+    var value = buffer[offset];
+    return result.reset(null, offset + this.width, value);
+};
+
+I8RW.prototype.poolWriteInto = function poolWriteInto(result, value, buffer, offset) {
+    var coerced = +value;
+    if ((typeof value !== 'string' && typeof value !== 'number') || !isFinite(coerced)) {
+        return result.reset(new ebufrw.InvalidArgument({
+            expected: 'a number'
+        }));
+    }
+
+    var remain = buffer.length - offset;
+    if (remain < this.width) {
+        return bufrw.WriteResult.poolShortError(result, this.width, remain, offset);
+    }
+
+    if (value < this.min || value > this.max) {
+        return result.reset(new ebufrw.RangeError({
+            value: coerced,
+            min: this.min,
+            max: this.max
+        }));
+    }
+
+    buffer[offset] = coerced;
+    return result.reset(null, offset + this.width);
+};
+
+I8RW.prototype.poolByteLength = function poolByteLength(result, value) {
+    return result.reset(null, this.width);
+};
+
 
 function ThriftI8() { }
 
-ThriftI8.prototype.rw = I8RW;
+ThriftI8.prototype.rw = new I8RW();
 ThriftI8.prototype.name = 'i8';
 ThriftI8.prototype.typeid = TYPE.I8;
 ThriftI8.prototype.surface = Number;

--- a/test/i16.js
+++ b/test/i16.js
@@ -30,16 +30,59 @@ var ThriftI16 = thriftrw.ThriftI16;
 var TYPE = require('../TYPE');
 
 /*eslint-disable space-in-brackets,no-multi-spaces*/
-var validTestCases = [
+var testCases = [
     [-0x1234, [0xed, 0xcc]],
     [      0, [0x00, 0x00]],
-    [ 0x1234, [0x12, 0x34]]
+    [ 0x1234, [0x12, 0x34]],
+
+    {
+        writeTest: {
+            value: '10',
+            bytes: [0x00, 0x0a]
+        }
+    },
+    {
+        writeTest: {
+            value: 0xffff,
+            bytes: [0xff, 0xff],
+            error: {
+                message: 'value 65535 out of range, min: -32768 max: 32767',
+                name: 'BufrwRangeErrorError',
+                type: 'bufrw.range-error'
+            }
+        }
+    },
+
+    {
+        readTest: {
+            bytes: [],
+            error: {
+                // message: 'short read, 4 bytes needed after consuming 0'
+                // TODO validate message (currently incorrect)
+                name: 'BufrwShortReadError',
+                type: 'bufrw.short-read'
+            }
+        }
+    },
+
+    {
+        writeTest: {
+            value: '+255',
+            bytes: [0x00, 0xff]
+        }
+    },
+    {
+        writeTest: {
+            value: 'hello',
+            error: {
+                type: 'bufrw.invalid-argument',
+                name: 'BufrwInvalidArgumentError',
+                message: 'invalid argument, expected a number'
+            }
+        }
+    }
 ];
 /*eslint-enable space-in-brackets,no-multi-spaces*/
 
-var testCases = [].concat(
-    validTestCases
-);
-
-test('I16RW', testRW.cases(I16RW, testCases));
-test('ThriftI16', testThrift(ThriftI16, I16RW, TYPE.I16));
+test('I16RW', testRW.cases(new I16RW(), testCases));
+test('ThriftI16', testThrift(ThriftI16, ThriftI16.prototype.rw, TYPE.I16));

--- a/test/i32.js
+++ b/test/i32.js
@@ -30,16 +30,59 @@ var ThriftI32 = thriftrw.ThriftI32;
 var TYPE = require('../TYPE');
 
 /*eslint-disable space-in-brackets*/
-var validTestCases = [
+var testCases = [
     [-0x12345678, [0xed, 0xcb, 0xa9, 0x88]],
     [ 0x00000000, [0x00, 0x00, 0x00, 0x00]],
-    [ 0x12345678, [0x12, 0x34, 0x56, 0x78]]
+    [ 0x12345678, [0x12, 0x34, 0x56, 0x78]],
+
+    {
+        writeTest: {
+            value: '10',
+            bytes: [0x00, 0x00, 0x00, 0x0a]
+        }
+    },
+    {
+        writeTest: {
+            value: '+255',
+            bytes: [0x00, 0x00, 0x00, 0xff]
+        }
+    },
+
+    {
+        readTest: {
+            bytes: [],
+            error: {
+                // message: 'short read, 4 bytes needed after consuming 0'
+                // TODO validate message (currently incorrect)
+                name: 'BufrwShortReadError',
+                type: 'bufrw.short-read'
+            }
+        }
+    },
+
+    {
+        writeTest: {
+            value: 0xffffffff,
+            bytes: [0xff, 0xff, 0xff, 0xff],
+            error: {
+                message: 'value 4294967295 out of range, min: -2147483648 max: 2147483647',
+                name: 'BufrwRangeErrorError',
+                type: 'bufrw.range-error'
+            }
+        }
+    },
+    {
+        writeTest: {
+            value: 'hello',
+            error: {
+                type: 'bufrw.invalid-argument',
+                name: 'BufrwInvalidArgumentError',
+                message: 'invalid argument, expected a number'
+            }
+        }
+    }
 ];
 /*eslint-enable space-in-brackets*/
 
-var testCases = [].concat(
-    validTestCases
-);
-
-test('I32RW', testRW.cases(I32RW, testCases));
-test('ThriftI32', thriftTest(ThriftI32, I32RW, TYPE.I32));
+test('I32RW', testRW.cases(new I32RW(), testCases));
+test('ThriftI32', thriftTest(ThriftI32, ThriftI32.prototype.rw, TYPE.I32));

--- a/test/i8.js
+++ b/test/i8.js
@@ -36,7 +36,30 @@ var Buffer = require('buffer').Buffer;
 
 var validTestCases = [
     [0x00, [0x00]], // min: 0
-    [0x7f, [0x7f]]  // max: 127
+    [0x7f, [0x7f]],  // max: 127
+    {
+        writeTest: {
+            value: '1',
+            bytes: [0x01]
+        }
+    },
+    {
+        writeTest: {
+            value: '0',
+            bytes: [0x00]
+        }
+    },
+    {
+        writeTest: {
+            value: 0xff,
+            bytes: [0xff],
+            error: {
+                message: 'value 255 out of range, min: -128 max: 127',
+                name: 'BufrwRangeErrorError',
+                type: 'bufrw.range-error'
+            }
+        }
+    },
 ];
 
 var invalidArgumentTestCases = [
@@ -83,8 +106,8 @@ var testCases = [].concat(
     outOfRangeTestCases
 );
 
-test('I8RW', testRW.cases(I8RW, testCases));
-test('ThriftI8', testThrift(ThriftI8, I8RW, TYPE.BYTE));
+test('I8RW', testRW.cases(ThriftI8.prototype.rw, testCases));
+test('ThriftI8', testThrift(ThriftI8, ThriftI8.prototype.rw, TYPE.I8));
 
 test('Thrift i8 IDL', function t(assert) {
     var thrift = new Thrift({
@@ -92,6 +115,6 @@ test('Thrift i8 IDL', function t(assert) {
         allowFilesystemAccess: true
     });
     assert.equal(thrift.typedefs.piecesOf8, Number, 'should surface a number');
-    assert.equal(thrift.models.piecesOf8.to.rw, I8RW, 'should refer to I8 rw');
+    assert.equal(thrift.models.piecesOf8.to.rw, ThriftI8.prototype.rw, 'should refer to I8 rw');
     assert.end();
 });

--- a/test/map.js
+++ b/test/map.js
@@ -26,21 +26,15 @@ var path = require('path');
 var fs = require('fs');
 var ThriftMap = require('../map').ThriftMap;
 var Thrift = require('../thrift').Thrift;
-var thrift;
 
-var ThriftString = require('../string').ThriftString;
-var ThriftI16 = require('../i16').ThriftI16;
+var filename = path.join(__dirname, 'map.thrift');
+var source = fs.readFileSync(filename, 'ascii');
+var thrift = new Thrift({source: source});
 
-test('thrift parses', function t(assert) {
-    var filename = path.join(__dirname, 'map.thrift');
-    var source = fs.readFileSync(filename, 'ascii');
-    thrift = new Thrift({source: source});
-    thrift.getType('Graph');
-    assert.pass('thrift parses');
-    assert.end();
-});
+var strI16Map = thrift.models.Graph.fieldsByName.stringsToI16s.valueType;
+var strI16MapEntries = thrift.models.Graph.fieldsByName.stringsToI16Entries.valueType;
+var i16I16Map = thrift.models.Graph.fieldsByName.i16sToI16s;
 
-var strI16Map = new ThriftMap(new ThriftString(), new ThriftI16(), {});
 test('ThriftMap: strI16MapRW', testRW.cases(strI16Map.rw, [
     [{}, [
         0x0b,                  // key_type:1 -- 11, string
@@ -104,8 +98,6 @@ test('ThriftMap: strI16MapRW', testRW.cases(strI16Map.rw, [
 
 ]));
 
-var strI16MapEntries = new ThriftMap(new ThriftString(), new ThriftI16(),
-    {'js.type': 'entries'});
 test('ThriftMap: strI16MapRW', testRW.cases(strI16MapEntries.rw, [
     [[], [
         0x0b,                  // key_type:1 -- 11, string
@@ -167,6 +159,36 @@ test('ThriftMap: strI16MapRW', testRW.cases(strI16MapEntries.rw, [
         }
     }
 
+]));
+
+test('map<i8, i8>', testRW.cases(thrift.models.MapI8I8.rw, [
+    [{2: 3}, [
+        0x03,                   // key_type:1 -- 3, i8
+        0x03,                   // val_type:1 -- 3, i8
+        0x00, 0x00, 0x00, 0x01, // length:4   -- 1
+        0x02,                   // [0] key -- 2
+        0x03                    // [1] value -- 3
+    ]]
+]));
+
+test('map<i16, i16>', testRW.cases(thrift.models.MapI16I16.rw, [
+    [{2: 3}, [
+        0x06,                   // key_type:1 -- 6, i16
+        0x06,                   // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x01, // length:4   -- 1
+        0x00, 0x02,             // [0] key -- 2
+        0x00, 0x03              // [1] value -- 3
+    ]]
+]));
+
+test('map<i32, i32>', testRW.cases(thrift.models.MapI32I32.rw, [
+    [{2: 3}, [
+        0x08,                   // key_type:1 -- 8, i32
+        0x08,                   // val_type:1 -- 8, i32
+        0x00, 0x00, 0x00, 0x01, // length:4   -- 1
+        0x00, 0x00, 0x00, 0x02, // [0] key -- 2
+        0x00, 0x00, 0x00, 0x03  // [1] value -- 3
+    ]]
 ]));
 
 test('invalid map type annotation', function t(assert) {

--- a/test/map.thrift
+++ b/test/map.thrift
@@ -1,3 +1,7 @@
+typedef map<i8, i8> MapI8I8
+typedef map<i16, i16> MapI16I16
+typedef map<i32, i32> MapI32I32
 struct Graph {
-    1: required map<string, i16> edges
+    1: required map<string, i16> stringsToI16s
+    1: required map<string, i16> (js.type = 'entries') stringsToI16Entries
 }


### PR DESCRIPTION
r @prashantv @yarpc/yarpc @yarpc/node

I’ve invited reviewers who do not have context:

This solves the problem that we could not support map<i32, i32> before, because they would by default be stored in an object with string keys. The i32 RW would refuse to coerce the string key to a number. This change solves the problem for all integer types, but not double, boolean, or i64.

i64 remains problematic because I made the decision to coerce strings of hex.