### PR TITLE
Allow undefined to be default value rather than null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# vNEXT // FIXME
+
+- Allow undefined to be default value rather than null
+- (c) 2017 (#146)
+
+# v3.9.0
+- revert thrift-idl cache option
+
 # v3.8.0
 
 - Thread annotations for individual enum definitions

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ var source = fs.readFileSync(path.join(__dirname, 'meta.thrift'), 'ascii');
 var thrift = new Thrift({
     source: source,
     strict: true,
-    allowOptionalArguments: true
+    allowOptionalArguments: true,
+    defaultAsUndefined: false
 });
 ```
 
@@ -190,7 +191,8 @@ typically by inbound request handlers in servers.
 
 If a client uses the provided constructor for the struct, the constructor will
 populate the default value as well, so in that sense clients also infer the
-default value.
+default value. The default value used is the null object unless the `defaultAsUndefined`
+flag is set in the user-defined options. In such a case, undefined will be used, instead.
 
 However, callers are not obliged to use the constructor for the struct. In that
 case, if the value is missing, ThriftRW does not write it to the wire and
@@ -383,8 +385,8 @@ var result = new ResultStruct({
 })
 ```
 
-Unspecified properties will default to null or an instance of the default value
-specified in the Thrift IDL.
+Unspecified properties will default to null (undefined if defaultAsUndefined flag was set)
+or an instance of the default value specified in the Thrift IDL.
 Nested structs can be expressed with JSON or POJO equivalents.
 The constructors perform no validation.
 Invalid objects are revealed only in the attempt to write one to a buffer.

--- a/struct.js
+++ b/struct.js
@@ -49,9 +49,8 @@ function ThriftField(def, struct) {
     this.optional = def.optional;
     this.valueDefinition = def.valueType;
     this.valueType = null;
-    this.defaultValueDefinition = def.defaultValue;
+    this.defaultValueDefinition = def.defaultValue || struct.defaultValueDefinition;
     this.defaultValue = null;
-    this.constructDefaultValue = null;
     this.annotations = def.annotations;
 }
 
@@ -70,6 +69,7 @@ function ThriftStruct(options) {
     this.name = null;
     // Strict mode is on by default. Because we have strict opinions about Thrift.
     this.strict = options.strict !== undefined ? options.strict : true;
+    this.defaultValueDefinition = options.defaultValueDefinition;
     // TODO bring in serviceName
     this.fields = [];
     this.fieldNames = [];
@@ -249,7 +249,7 @@ ThriftStruct.prototype.createConstructor = function createConstructor(name, fiel
         source += '    this.' + field.name + ' = null;\n';
         source += '    if (options && typeof options.' + field.name + ' !== "undefined") ' +
             '{ this.' + field.name + ' = options.' + field.name + '; }\n';
-        if (field.defaultValue !== null) {
+        if (field.defaultValue !== null && field.defaultValue !== undefined) {
             source += '    else { this.' + field.name +
                 ' = ' + JSON.stringify(field.defaultValue) + '; }\n';
         }

--- a/test/struct.js
+++ b/test/struct.js
@@ -551,7 +551,6 @@ test('allows undefined as default', function t(assert) {
         ]
     }, {allowOptionalArguments: true});
     defaultStruct.link(tMock);
-    console.log(defaultStruct);
     assert.true(defaultStruct.fieldsByName.testDefault.defaultValue === undefined, 'Default value is undefined');
     assert.end();
 });

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -185,6 +185,25 @@ test('get endpoints multi service', function t(assert) {
     assert.end();
 });
 
+test('respects default as undefined', function t(assert) {
+    var filename = path.join(__dirname, 'thrift', 'MultiService.thrift');
+    thrift = new Thrift({
+        entryPoint: filename,
+        allowFilesystemAccess: true,
+        defaultAsUndefined: true
+    });
+    var valueDefinition = thrift.defaultValueDefinition;
+    assert.true(
+        valueDefinition.type === 'Literal',
+        'Correct value definition type'
+    );
+    assert.true(
+        valueDefinition.value === undefined,
+        'Correct value definition value'
+    );
+    assert.end();
+});
+
 test('get endpoints multi service target', function t(assert) {
     var filename = path.join(__dirname, 'thrift', 'MultiService.thrift');
     thrift = new Thrift({

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -204,6 +204,24 @@ test('respects default as undefined', function t(assert) {
     assert.end();
 });
 
+test('defaults to null default value', function t(assert) {
+    var filename = path.join(__dirname, 'thrift', 'MultiService.thrift');
+    thrift = new Thrift({
+        entryPoint: filename,
+        allowFilesystemAccess: true
+    });
+    var valueDefinition = thrift.defaultValueDefinition;
+    assert.true(
+        valueDefinition.type === 'Literal',
+        'Correct value definition type'
+    );
+    assert.true(
+        valueDefinition.value === null,
+        'Correct value definition value'
+    );
+    assert.end();
+});
+
 test('get endpoints multi service target', function t(assert) {
     var filename = path.join(__dirname, 'thrift', 'MultiService.thrift');
     thrift = new Thrift({

--- a/thrift.js
+++ b/thrift.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* eslint max-statements:[1, 42] */
+/* eslint max-statements:[1, 43] */
 'use strict';
 
 var assert = require('assert');
@@ -48,6 +48,8 @@ var ThriftSet = require('./set').ThriftSet;
 var ThriftMap = require('./map').ThriftMap;
 var ThriftConst = require('./const').ThriftConst;
 var ThriftTypedef = require('./typedef').ThriftTypedef;
+
+var Literal = require('./ast').Literal;
 
 var Message = require('./message').Message;
 var messageExceptionDef = require('./message').exceptionDef;
@@ -82,6 +84,7 @@ function Thrift(options) {
     }
 
     this.strict = options.strict !== undefined ? options.strict : true;
+    this.defaultValueDefinition = new Literal(options.defaultAsUndefined ? undefined : null);
 
     // [name] :Thrift* implementing {compile, link, &c}
     // Heterogenous Thrift model objects by name in a consolidated name-space
@@ -299,7 +302,7 @@ Thrift.prototype.compileInclude = function compileInclude(def) {
 };
 
 Thrift.prototype.compileStruct = function compileStruct(def) {
-    var model = new ThriftStruct({strict: this.strict});
+    var model = new ThriftStruct({strict: this.strict, defaultValueDefinition: this.defaultValueDefinition});
     model.compile(def, this);
     this.define(model.fullName, def, model);
     return model;


### PR DESCRIPTION
We would rather lose structure and allow undefined to be our default value in some circumstances (when serializing to JSON). Add ability to optionally use undefined as the default value.