### PR TITLE
Fix constructor for undefined default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# vNEXT // FIXME
+
+- Fix constructor support for undefined default values. This allows either
+  undefined or null to be used in the constructor.
+
 # v3.10.0
 
 - Adds an `defaultAsUndefined` option to the Thrift constructor that causes

--- a/struct.js
+++ b/struct.js
@@ -246,13 +246,10 @@ ThriftStruct.prototype.createConstructor = function createConstructor(name, fiel
     source = '(function thriftrw_' + name + '(options) {\n';
     for (var index = 0; index < fields.length; index++) {
         var field = fields[index];
-        source += '    this.' + field.name + ' = null;\n';
         source += '    if (options && typeof options.' + field.name + ' !== "undefined") ' +
             '{ this.' + field.name + ' = options.' + field.name + '; }\n';
-        if (field.defaultValue !== null && field.defaultValue !== undefined) {
-            source += '    else { this.' + field.name +
-                ' = ' + JSON.stringify(field.defaultValue) + '; }\n';
-        }
+        source += '    else { this.' + field.name +
+            ' = ' + JSON.stringify(field.defaultValue) + '; }\n';
     }
     source += '})\n';
     // eval is an operator that captures the lexical scope of the calling

--- a/test/default.js
+++ b/test/default.js
@@ -35,6 +35,14 @@ test('default values on structs work', function t(assert) {
     assert.equals(health.notOk, false, 'default false value passes through');
     assert.equals(health.message, 'OK', 'default string passes through');
     assert.equals(health.name, 'grand', 'option overrides default');
+    assert.equals(health.respected, null, 'null is default value');
     assert.deepEquals(health.numbers, [1, 2, 3], 'complex defaults serialize');
+    assert.end();
+});
+
+test('default value as undefined respected in constructor', function t(assert) {
+    model = new Thrift({source: source, defaultAsUndefined: true});
+    var health = new model.Health({name: 'grand'});
+    assert.equals(health.respected, undefined, 'undefined as default value');
     assert.end();
 });

--- a/test/default.thrift
+++ b/test/default.thrift
@@ -5,4 +5,5 @@ struct Health {
     3: string message = 'OK'
     4: string name = 'alright'
     5: list<i32> numbers = numbers
+    6: optional string respected
 }


### PR DESCRIPTION
Previously null was the default, default value. [This commit](https://github.com/thriftrw/thriftrw-node/commit/34a8b1b80a46482cbbc3777c7a635d57db59d59b) allowed the user to specify undefined as a default value as well, but it did not change the creation of the constructor. In order to allow undefined or null to be used as the default value, always use the default value if a value for the field is not provided in the options.