### PR TITLE
Fix negative long number encoding

### DIFF
--- a/i64.js
+++ b/i64.js
@@ -45,8 +45,9 @@ I64RW.prototype.poolWriteInto = function poolWriteInto(destResult, value, buffer
     if (value instanceof Buffer) {
         return this.writeBufferInt64Into(destResult, value, buffer, offset);
     } else if (typeof value === 'number') {
-        buffer.writeInt32BE(value / Math.pow(2, 32), offset, true);
-        buffer.writeInt32BE(value, offset + 4, true);
+        var number = Long.fromNumber(value);
+        buffer.writeInt32BE(number.high, offset, true);
+        buffer.writeInt32BE(number.low, offset + 4, true);
         return destResult.reset(null, offset + 8);
     } else if (Array.isArray(value)) {
         return this.writeArrayInt64Into(destResult, value, buffer, offset);

--- a/test/i64.js
+++ b/test/i64.js
@@ -55,6 +55,15 @@ var longCases = [
     ]
 ];
 
+test('I64LongRW negatives', function t(assert) {
+    var buffer = new Buffer(8);
+    longRW.poolWriteInto({
+        reset: function (val, err) {}
+    }, -1, buffer, 0);
+    assert.deepEquals(buffer, new Buffer('ffffffffffffffff', 'hex'), 'writen value is negative')
+    assert.end();
+});
+
 test('I64LongRW', testRW.cases(longRW, longCases));
 
 var dateCases = [


### PR DESCRIPTION
Previously, when encoding a plain JavaScript Number for a i64 with the (js.type
= 'Long') annotation, the high four bits would be masked out to zero, resulting
in a large 32 bit integer. This change runs the number through the Long library
to ensure that the high bits are all set for negative numbers less than 32 bits
wide.

r @jakemh