### PR TITLE
Fix i64 Date test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - "0.10"
   - "4"
+  - "8"
 script: npm run travis

--- a/test/i64.js
+++ b/test/i64.js
@@ -192,7 +192,7 @@ test('fail to coerce', function t(assert) {
 test('coerce date string', function t(assert) {
     var buffer = new Buffer(8);
     buffer.fill(0xff);
-    dateRW.writeInto('1970-01-01T00:00:00.000', buffer, 0);
+    dateRW.writeInto('1970-01-01T00:00:00.000Z', buffer, 0);
     assert.deepEquals(buffer, new Buffer([0, 0, 0, 0, 0, 0, 0, 0]), 'coerces date string');
     assert.end();
 });

--- a/thrift.js
+++ b/thrift.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* eslint max-statements:[1, 43] */
+/* eslint max-statements:[1, 45] */
 'use strict';
 
 var assert = require('assert');


### PR DESCRIPTION
Node 8 changed the behavior of Date.parse.
The default timezone changed.
This change now makes the UTC timezone explicit.