### PR TITLE
Remove relative path checks in thrift includes

### DIFF
--- a/test/include-nonrelative-alias.thrift
+++ b/test/include-nonrelative-alias.thrift
@@ -1,0 +1,1 @@
+include common "typedef.thrift"

--- a/test/include-nonrelative-filename.thrift
+++ b/test/include-nonrelative-filename.thrift
@@ -1,0 +1,1 @@
+include "typedef.thrift"

--- a/test/include.js
+++ b/test/include.js
@@ -124,8 +124,8 @@ test('cyclic dependencies', function t(assert) {
 test('bad include paths', function t(assert) {
     assert.throws(
         badIncludePaths,
-        /Include path string must start with either .\/ or ..\//,
-        'include throws without ./ or ../'
+        /ENOENT\: no such file or directory/,
+	'include throws ENOTFOUND'
     );
     assert.end();
 
@@ -195,4 +195,34 @@ test('includes from opts.source throws', function t(assert) {
             allowIncludeAlias: true
         });
     }
+});
+
+test('include non-relative filename', function t(assert) {
+    var thrift = new Thrift({
+        entryPoint: path.join(
+            __dirname,
+            'include-nonrelative-filename.thrift'
+        ),
+        allowIncludeAlias: true,
+        allowFilesystemAccess: true
+    });
+
+    assert.ok(thrift.modules.typedef,
+        'modules includes typedef thrift instance');
+    assert.end();
+});
+
+test('include non-relative filename with alias', function t(assert) {
+    var thrift = new Thrift({
+        entryPoint: path.join(
+            __dirname,
+            'include-nonrelative-alias.thrift'
+        ),
+        allowIncludeAlias: true,
+        allowFilesystemAccess: true
+    });
+
+    assert.ok(thrift.modules.common.typedefs,
+        'modules includes typedef thrift instance');
+    assert.end();
 });

--- a/thrift.js
+++ b/thrift.js
@@ -254,52 +254,46 @@ Thrift.prototype._compile = function _compile(defs) {
 };
 
 Thrift.prototype.compileInclude = function compileInclude(def) {
-    if (def.id.lastIndexOf('./', 0) === 0 ||
-        def.id.lastIndexOf('../', 0) === 0) {
-        var ns = def.namespace && def.namespace.name;
-        var filename = path.join(this.dirname, def.id);
+    var ns = def.namespace && def.namespace.name;
+    var filename = path.join(this.dirname, def.id);
 
-        // If include isn't name, get filename sans *.thrift file extension.
-        if (!this.allowIncludeAlias || !ns) {
-            var basename = path.basename(def.id);
-            ns = basename.slice(0, basename.length - 7);
-            if (!validThriftIdentifierRE.test(ns)) {
-                throw Error(
-                    'Thrift include filename is not valid thrift identifier'
-                );
-            }
+    // If include isn't name, get filename sans *.thrift file extension.
+    if (!this.allowIncludeAlias || !ns) {
+        var basename = path.basename(def.id);
+        ns = basename.slice(0, basename.length - 7);
+        if (!validThriftIdentifierRE.test(ns)) {
+            throw Error(
+                'Thrift include filename is not valid thrift identifier'
+            );
         }
+    }
 
-        var model;
+    var model;
 
-        if (this.memo[filename]) {
-            model = this.memo[filename];
-        } else {
-            model = new Thrift({
-                entryPoint: filename,
-                fs: this.fs,
-                idls: this.idls,
-                asts: this.asts,
-                memo: this.memo,
-                strict: this.strict,
-                allowIncludeAlias: true,
-                allowOptionalArguments: this.allowOptionalArguments,
-                noLink: true,
-                defaultAsUndefined: this.defaultAsUndefined
-            });
-        }
-
-        this.define(ns, def, model);
-
-        // Alias if first character is not lower-case
-        this.modules[ns] = model;
-
-        if (!/^[a-z]/.test(ns)) {
-            this[ns] = model;
-        }
-
+    if (this.memo[filename]) {
+        model = this.memo[filename];
     } else {
-        throw Error('Include path string must start with either ./ or ../');
+        model = new Thrift({
+            entryPoint: filename,
+            fs: this.fs,
+            idls: this.idls,
+            asts: this.asts,
+            memo: this.memo,
+            strict: this.strict,
+            allowIncludeAlias: true,
+            allowOptionalArguments: this.allowOptionalArguments,
+            noLink: true,
+            defaultAsUndefined: this.defaultAsUndefined
+        });
+    }
+
+    this.define(ns, def, model);
+
+    // Alias if first character is not lower-case
+    this.modules[ns] = model;
+
+    if (!/^[a-z]/.test(ns)) {
+        this[ns] = model;
     }
 };
 


### PR DESCRIPTION
Rest of the thriftrw language clients have support for just having `include "typedefs.thrift"` instead of specifying relative path as in `include "./typedefs.thrift"`