### PR TITLE
Improved _args not found error to be more helpful.

### DIFF
--- a/test/thrift-idl.js
+++ b/test/thrift-idl.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -119,7 +119,7 @@ test('can get type error result from thrift', function t(assert) {
     var res = thrift.getTypeResult('Bogus');
     assert.ok(res.err, 'got error');
     if (!res.err) return assert.end();
-    assert.equal(res.err.message, 'type Bogus not found');
+    assert.equal(res.err.message, 'type Bogus not found. Make sure that the service name matches a service in the thrift file and that the method name is nested under that service.');
     assert.end();
 });
 
@@ -128,7 +128,7 @@ test('can get type error from thrift', function t(assert) {
         thrift.getType('Bogus');
         assert.fail('error expected');
     } catch (err) {
-        assert.equal(err.message, 'type Bogus not found');
+        assert.equal(err.message, 'type Bogus not found. Make sure that the service name matches a service in the thrift file and that the method name is nested under that service.');
     }
     assert.end();
 });

--- a/thrift-idl.js
+++ b/thrift-idl.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/thrift.js
+++ b/thrift.js
@@ -152,10 +152,10 @@ Thrift.prototype.getType = function getType(name) {
     return this.getTypeResult(name).toValue();
 };
 
-Thrift.prototype.getTypeResult = function getType(name) {
+Thrift.prototype.getTypeResult = function getTypeResult(name) {
     var model = this.models[name];
     if (!model || model.models !== 'type') {
-        return new Result(new Error(util.format('type %s not found', name)));
+        return new Result(new Error(util.format('type %s not found. Make sure that the service name matches a service in the thrift file and that the method name is nested under that service.', name)));
     }
     return new Result(null, model.link(this));
 };


### PR DESCRIPTION
The "XYZ_args not found" error can be caused by an invalid service name or a method name that is not found within the service. The error should help the user understand this issue.