### PR TITLE
Fix buffer over-read errors

### DIFF
--- a/i16.js
+++ b/i16.js
@@ -37,7 +37,10 @@ I16RW.prototype.min = -0x7fff - 1;
 I16RW.prototype.max = 0x7fff;
 
 I16RW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
-    var value = buffer.readInt16BE(offset, true);
+    var value;
+    if (buffer.length >= offset + this.width) {
+        value = buffer.readInt16BE(offset);
+    }
     return result.reset(null, offset + this.width, value);
 };
 

--- a/i32.js
+++ b/i32.js
@@ -37,7 +37,10 @@ I32RW.prototype.min = -0x7fffffff - 1;
 I32RW.prototype.max = 0x7fffffff;
 
 I32RW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
-    var value = buffer.readInt32BE(offset, true);
+    var value;
+    if (buffer.length >= offset + this.width) {
+        value = buffer.readInt32BE(offset);
+    }
     return result.reset(null, offset + this.width, value);
 };
 


### PR DESCRIPTION
Older versions of Node.js were more hospitable to reading past the end of a buffer.  This change addresses an error that occurs in tests that read past the end of the buffer to induce errors.