### PR TITLE
No buffer asserts

### DIFF
--- a/i16.js
+++ b/i16.js
@@ -37,6 +37,14 @@ I16RW.prototype.min = -0x7fff - 1;
 I16RW.prototype.max = 0x7fff;
 
 I16RW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
+    var remain = buffer.length - offset;
+    if (remain < this.width) {
+        return result.reset(ebufrw.ShortRead({
+            remaining: remain,
+            buffer: buffer,
+            offset: offset,
+        }), offset);
+    }
     var value = buffer.readInt16BE(offset);
     return result.reset(null, offset + this.width, value);
 };

--- a/i16.js
+++ b/i16.js
@@ -37,7 +37,7 @@ I16RW.prototype.min = -0x7fff - 1;
 I16RW.prototype.max = 0x7fff;
 
 I16RW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
-    var value = buffer.readInt16BE(offset, true);
+    var value = buffer.readInt16BE(offset);
     return result.reset(null, offset + this.width, value);
 };
 
@@ -63,7 +63,7 @@ I16RW.prototype.poolWriteInto = function poolWriteInto(result, value, buffer, of
         }));
     }
 
-    buffer.writeInt16BE(coerced, offset, true);
+    buffer.writeInt16BE(coerced, offset);
     return result.reset(null, offset + this.width);
 };
 

--- a/i32.js
+++ b/i32.js
@@ -37,7 +37,7 @@ I32RW.prototype.min = -0x7fffffff - 1;
 I32RW.prototype.max = 0x7fffffff;
 
 I32RW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
-    var value = buffer.readInt32BE(offset, true);
+    var value = buffer.readInt32BE(offset);
     return result.reset(null, offset + this.width, value);
 };
 
@@ -63,7 +63,7 @@ I32RW.prototype.poolWriteInto = function poolWriteInto(result, value, buffer, of
         }));
     }
 
-    buffer.writeInt32BE(coerced, offset, true);
+    buffer.writeInt32BE(coerced, offset);
     return result.reset(null, offset + this.width);
 };
 

--- a/i32.js
+++ b/i32.js
@@ -37,6 +37,14 @@ I32RW.prototype.min = -0x7fffffff - 1;
 I32RW.prototype.max = 0x7fffffff;
 
 I32RW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
+    var remain = buffer.length - offset;
+    if (remain < this.width) {
+        return result.reset(ebufrw.ShortRead({
+            remaining: remain,
+            buffer: buffer,
+            offset: offset,
+        }), offset);
+    }
     var value = buffer.readInt32BE(offset);
     return result.reset(null, offset + this.width, value);
 };

--- a/i64.js
+++ b/i64.js
@@ -46,8 +46,8 @@ I64RW.prototype.poolWriteInto = function poolWriteInto(destResult, value, buffer
         return this.writeBufferInt64Into(destResult, value, buffer, offset);
     } else if (typeof value === 'number') {
         var number = Long.fromNumber(value);
-        buffer.writeInt32BE(number.high, offset, true);
-        buffer.writeInt32BE(number.low, offset + 4, true);
+        buffer.writeInt32BE(number.high, offset);
+        buffer.writeInt32BE(number.low, offset + 4);
         return destResult.reset(null, offset + 8);
     } else if (Array.isArray(value)) {
         return this.writeArrayInt64Into(destResult, value, buffer, offset);
@@ -76,8 +76,8 @@ function writeObjectInt64Into(destResult, value, buffer, offset) {
             '{hi[gh], lo[w]} with low bits, or other i64 representation'), null);
     }
     // Does not validate range of hi or lo value
-    buffer.writeInt32BE(value.high || value.hi, offset, true);
-    buffer.writeInt32BE(value.low || value.lo, offset + 4, true);
+    buffer.writeInt32BE(value.high || value.hi, offset);
+    buffer.writeInt32BE(value.low || value.lo, offset + 4);
     return destResult.reset(null, offset + 8);
 };
 
@@ -124,8 +124,8 @@ util.inherits(I64LongRW, I64RW);
 
 I64LongRW.prototype.poolReadFrom = function poolReadFrom(destResult, buffer, offset) {
     var value = Long.fromBits(
-        buffer.readInt32BE(offset + 4, 4, true),
-        buffer.readInt32BE(offset, 4, true)
+        buffer.readInt32BE(offset + 4, 4),
+        buffer.readInt32BE(offset, 4)
     );
     return destResult.reset(null, offset + 8, value);
 };
@@ -138,8 +138,8 @@ util.inherits(I64DateRW, I64RW);
 
 I64DateRW.prototype.poolReadFrom = function poolReadFrom(destResult, buffer, offset) {
     var long = Long.fromBits(
-        buffer.readInt32BE(offset + 4, 4, true),
-        buffer.readInt32BE(offset + 0, 4, true)
+        buffer.readInt32BE(offset + 4, 4),
+        buffer.readInt32BE(offset + 0, 4)
     );
     var ms = long.toNumber();
     var value = new Date(ms);

--- a/i8.js
+++ b/i8.js
@@ -37,6 +37,14 @@ I8RW.prototype.min = -0x7f - 1;
 I8RW.prototype.max = 0x7f;
 
 I8RW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
+    var remain = buffer.length - offset;
+    if (remain < this.width) {
+        return result.reset(ebufrw.ShortRead({
+            remaining: remain,
+            buffer: buffer,
+            offset: offset,
+        }), offset);
+    }
     var value = buffer[offset];
     return result.reset(null, offset + this.width, value);
 };

--- a/message.js
+++ b/message.js
@@ -194,7 +194,7 @@ MessageRW.prototype.poolLegacyWriteInto = function poolLegacyWriteInto(result, m
     // name~4 type:1 id:4
 
     // name.length:4
-    buffer.writeUInt32BE(message.name.length, offset, true);
+    buffer.writeUInt32BE(message.name.length, offset);
     offset += 4;
 
     // name:name.length
@@ -212,14 +212,14 @@ MessageRW.prototype.poolLegacyWriteInto = function poolLegacyWriteInto(result, m
     offset += 1;
 
     // id:4
-    buffer.writeUInt32BE(message.id, offset, true);
+    buffer.writeUInt32BE(message.id, offset);
     offset += 4;
 
     return result.reset(null, offset);
 };
 
 MessageRW.prototype.poolReadFrom = function poolReadFrom(result, buffer, offset) {
-    var msb = buffer.readInt8(offset, true);
+    var msb = buffer.readInt8(offset);
     if (msb < 0) {
         result = this.poolStrictReadFrom(result, buffer, offset);
     } else {
@@ -260,7 +260,7 @@ MessageRW.prototype.poolStrictReadFrom = function poolStrictReadFrom(result, buf
     // version:2 type:2 name~4 id:4
 
     var message = new Message();
-    message.version = buffer.readUInt16BE(offset, true) & ~0x8000; // mask out MSB
+    message.version = buffer.readUInt16BE(offset) & ~0x8000; // mask out MSB
     offset += 2;
 
     if (message.version !== 1) {
@@ -270,7 +270,7 @@ MessageRW.prototype.poolStrictReadFrom = function poolStrictReadFrom(result, buf
     }
 
     // type:2
-    var type = buffer.readUInt16BE(offset, true) & 0xFF;
+    var type = buffer.readUInt16BE(offset) & 0xFF;
     offset += 2;
 
     message.type = typeNames[type];
@@ -281,7 +281,7 @@ MessageRW.prototype.poolStrictReadFrom = function poolStrictReadFrom(result, buf
     }
 
     // name.length:4
-    var length = buffer.readUInt32BE(offset, true);
+    var length = buffer.readUInt32BE(offset);
     offset += 4;
 
     // name:name.length
@@ -289,7 +289,7 @@ MessageRW.prototype.poolStrictReadFrom = function poolStrictReadFrom(result, buf
     offset += length;
 
     // id:4
-    message.id = buffer.readUInt32BE(offset, true);
+    message.id = buffer.readUInt32BE(offset);
     offset += 4;
 
     return result.reset(null, offset, message);
@@ -300,7 +300,7 @@ MessageRW.prototype.poolLegacyReadFrom = function poolLegacyReadFrom(result, buf
     var message = new Message();
 
     // name.length
-    var length = buffer.readUInt32BE(offset, true);
+    var length = buffer.readUInt32BE(offset);
     offset += 4;
 
     // name:name.length
@@ -308,11 +308,11 @@ MessageRW.prototype.poolLegacyReadFrom = function poolLegacyReadFrom(result, buf
     offset += length;
 
     // type:2
-    var type = buffer.readUInt8(offset, true);
+    var type = buffer.readUInt8(offset);
     offset += 1;
 
     // id:4
-    message.id = buffer.readUInt32BE(offset, true);
+    message.id = buffer.readUInt32BE(offset);
     offset += 4;
 
     message.type = typeNames[type];

--- a/skip.js
+++ b/skip.js
@@ -45,8 +45,6 @@ skipVar[TYPE.SET] = skipList;
 skipVar[TYPE.LIST] = skipList;
 
 function skipField(destResult, buffer, offset) {
-
-    // istanbul ignore if
     if (offset + 1 > buffer.length) {
         return destResult.reset(bufrwErrors.ShortBuffer({
             expected: offset + 1,

--- a/skip.js
+++ b/skip.js
@@ -56,7 +56,7 @@ function skipField(destResult, buffer, offset) {
         }), offset);
     }
 
-    var typeid = buffer.readInt8(offset, true);
+    var typeid = buffer.readInt8(offset);
     offset += 1;
 
     return skipType(destResult, buffer, offset, typeid);
@@ -109,7 +109,7 @@ function skipStruct(destResult, buffer, offset) {
                 offset: offset
             }), offset);
         }
-        var typeid = buffer.readInt8(offset, true);
+        var typeid = buffer.readInt8(offset);
         offset += 1;
 
         if (typeid === TYPE.STOP) {
@@ -149,7 +149,7 @@ function skipString(destResult, buffer, offset) {
         }), offset);
     }
 
-    var length = buffer.readInt32BE(offset, true);
+    var length = buffer.readInt32BE(offset);
     offset += 4;
 
     // istanbul ignore if

--- a/test/i32.js
+++ b/test/i32.js
@@ -52,13 +52,24 @@ var testCases = [
         readTest: {
             bytes: [],
             error: {
-                // message: 'short read, 4 bytes needed after consuming 0'
-                // TODO validate message (currently incorrect)
+                message: 'short read, 0 byte left over after consuming 0',
                 name: 'BufrwShortReadError',
                 type: 'bufrw.short-read'
             }
         }
     },
+
+    {
+        readTest: {
+            bytes: [0, 0, 0],
+            error: {
+                message: 'short read, 3 byte left over after consuming 0',
+                name: 'BufrwShortReadError',
+                type: 'bufrw.short-read'
+            }
+        }
+    },
+
 
     {
         writeTest: {

--- a/test/i64.js
+++ b/test/i64.js
@@ -42,7 +42,26 @@ var dateRW = thrift.getType('timestamp').rw;
 var bufferCases = [
     [
         Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
-        [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
+        {
+            readTest: {
+                bytes: [],
+                error: {
+                    type: 'bufrw.short-read',
+                    name: 'BufrwShortReadError',
+                    message: 'short read, 0 byte left over after consuming 0'
+                },
+            },
+            writeTest: {
+                bytes: [],
+                value: 0,
+                error: {
+                    type: 'bufrw.short-buffer',
+                    name: 'BufrwShortBufferError',
+                    message: 'expected at least 8 bytes, only have 0 @0'
+                }
+            },
+        },
     ]
 ];
 
@@ -51,7 +70,39 @@ test('I64BufferRW', testRW.cases(bufferRW, bufferCases));
 var longCases = [
     [
         Long.fromNumber(Math.pow(2, 53) - 1),
-        [0x00, 0x1f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+        [0x00, 0x1f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+        {
+            readTest: {
+                bytes: [],
+                error: {
+                    type: 'bufrw.short-read',
+                    name: 'BufrwShortReadError',
+                    message: 'short read, 0 byte left over after consuming 0'
+                },
+            },
+        },
+        {
+            writeTest: {
+                bytes: [],
+                value: 0,
+                error: {
+                    type: 'bufrw.short-buffer',
+                    name: 'BufrwShortBufferError',
+                    message: 'expected at least 8 bytes, only have 0 @0'
+                }
+            },
+        },
+        {
+            writeTest: {
+                bytes: [],
+                value: {hi: 0, lo: 0},
+                error: {
+                    type: 'bufrw.short-buffer',
+                    name: 'BufrwShortBufferError',
+                    message: 'expected at least 8 bytes, only have 0 @0'
+                }
+            },
+        },
     ]
 ];
 
@@ -78,7 +129,28 @@ var dateCases = [
     [
         new Date(1000),
         [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xe8]
-    ]
+    ],
+    {
+        readTest: {
+            bytes: [],
+            error: {
+                type: 'bufrw.short-read',
+                name: 'BufrwShortReadError',
+                message: 'short read, 0 byte left over after consuming 0'
+            },
+        },
+    },
+    {
+        writeTest: {
+            bytes: [],
+            value: new Date(),
+            error: {
+                type: 'bufrw.short-buffer',
+                name: 'BufrwShortBufferError',
+                message: 'expected at least 8 bytes, only have 0 @0'
+            }
+        },
+    },
 ];
 
 test('I64DateRW', testRW.cases(dateRW, dateCases));

--- a/test/i8.js
+++ b/test/i8.js
@@ -86,6 +86,24 @@ var invalidShortBufferTestCases = [{
             message: 'expected at least 1 bytes, only have 0 @0'
         }
     }
+}, {
+    readTest: {
+        bytes: [],
+        error: {
+            type: 'bufrw.short-read',
+            name: 'BufrwShortReadError',
+            message: 'short read, 0 byte left over after consuming 0'
+        }
+    },
+    writeTest: {
+        bytes: [],
+        value: 0,
+        error: {
+            type: 'bufrw.short-buffer',
+            name: 'BufrwShortBufferError',
+            message: 'expected at least 1 bytes, only have 0 @0'
+        }
+    },
 }];
 
 var outOfRangeTestCases = [{

--- a/test/skip.js
+++ b/test/skip.js
@@ -174,3 +174,11 @@ function createCase(bytes) {
         assert.end();
     };
 }
+
+test('skip short buffer', function t(assert) {
+    var bytes = [];
+    var res = new ReadResult();
+    var result = skip(res, new Buffer(bytes), 0);
+    assert.ok(result.err !== null);
+    assert.end();
+});


### PR DESCRIPTION
Subsuming and following up to #156, this removes the use of the long-past-deprecated field bounds assertion argument and preempts it with explicit boundary checks and errors.