### PR TITLE
Restore decentralized testing

### DIFF
--- a/test/asts.js
+++ b/test/asts.js
@@ -20,7 +20,6 @@
 
 'use strict';
 
-var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var withLoader = require('./loader');
@@ -31,7 +30,7 @@ if (process.browser) {
     idls = global.idls;
 }
 
-withLoader(function (loadThrift) {
+withLoader(function (loadThrift, test) {
 
     test('can round trip a thrift file through sources', function t(assert) {
         loadThrift({

--- a/test/asts.js
+++ b/test/asts.js
@@ -20,17 +20,18 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var fs = require('fs');
-    var path = require('path');
+var allowFilesystemAccess = !process.browser;
+var idls;
+if (process.browser) {
+    idls = global.idls;
+}
 
-    var allowFilesystemAccess = !process.browser;
-    var idls;
-    if (process.browser) {
-        idls = global.idls;
-    }
+withLoader(function (loadThrift) {
 
     test('can round trip a thrift file through sources', function t(assert) {
         loadThrift({
@@ -40,12 +41,14 @@ module.exports = function(loadThrift) {
             allowIncludeAlias: true,
             idls: idls
         }, function (err, thrift) {
+            assert.ifError(err);
             var json = thrift.toJSON();
             loadThrift({
                 entryPoint: json.entryPoint,
                 asts: json.asts,
                 allowIncludeAlias: true
             }, function (err, rethrift) {
+                assert.ifError(err);
                 assert.deepEquals(
                     Object.keys(rethrift.models),
                     Object.keys(thrift.models),
@@ -66,4 +69,5 @@ module.exports = function(loadThrift) {
             assert.end();
         });
     });
-}
+
+});

--- a/test/binary.js
+++ b/test/binary.js
@@ -20,67 +20,64 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var testThrift = require('./thrift-test');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var testThrift = require('./thrift-test');
+var thriftrw = require('../index');
+var BinaryRW = thriftrw.BinaryRW;
+var ThriftBinary = thriftrw.ThriftBinary;
+var TYPE = require('../TYPE');
 
-    var thriftrw = require('../index');
-    var BinaryRW = thriftrw.BinaryRW;
-    var ThriftBinary = thriftrw.ThriftBinary;
-    var TYPE = require('../TYPE');
+var Buffer = require('buffer').Buffer;
 
-    var Buffer = require('buffer').Buffer;
+test('BinaryRW', testRW.cases(BinaryRW, [
 
-    test('BinaryRW', testRW.cases(BinaryRW, [
+    [Buffer(''), [
+        0x00, 0x00, 0x00, 0x00 // len:0
+    ]],
 
-        [Buffer(''), [
-            0x00, 0x00, 0x00, 0x00 // len:0
-        ]],
+    [Buffer([0x00, 0x88, 0xff]), [
+        0x00, 0x00, 0x00, 0x03, // len:3
+        0x00, 0x88, 0xff
+    ]],
 
-        [Buffer([0x00, 0x88, 0xff]), [
-            0x00, 0x00, 0x00, 0x03, // len:3
-            0x00, 0x88, 0xff
-        ]],
+    [Buffer('hello'), [
+        0x00, 0x00, 0x00, 0x05,       // len:5
+        0x68, 0x65, 0x6c, 0x6c, 0x6f  // chars  -- "hello"
+    ]],
 
-        [Buffer('hello'), [
-            0x00, 0x00, 0x00, 0x05,       // len:5
-            0x68, 0x65, 0x6c, 0x6c, 0x6f  // chars  -- "hello"
-        ]],
+    [Buffer('world'), [
+        0x00, 0x00, 0x00, 0x05,       // len:5
+        0x77, 0x6f, 0x72, 0x6c, 0x64  // chars  -- "world"
+    ]],
 
-        [Buffer('world'), [
-            0x00, 0x00, 0x00, 0x05,       // len:5
-            0x77, 0x6f, 0x72, 0x6c, 0x64  // chars  -- "world"
-        ]],
-
-        {
-            writeTest: {
-                value: null,
-                error: {
-                    type: 'bufrw.short-buffer',
-                    name: 'BufrwShortBufferError',
-                    message: 'expected at least 4 bytes, only have 0 @0'
-                }
-            }
-        },
-
-        {
-            readTest: {
-                value: Buffer([0x00, 0x01]),
-                bytes: [
-                    0x00, 0x00, 0x00, 0x03, // len:3
-                    0x00, 0x01
-                ],
-                error: {
-                    type: 'bufrw.short-buffer',
-                    name: 'BufrwShortBufferError',
-                    message: 'expected at least 3 bytes, only have 2 @[0:4]'
-                }
+    {
+        writeTest: {
+            value: null,
+            error: {
+                type: 'bufrw.short-buffer',
+                name: 'BufrwShortBufferError',
+                message: 'expected at least 4 bytes, only have 0 @0'
             }
         }
+    },
 
-    ]));
+    {
+        readTest: {
+            value: Buffer([0x00, 0x01]),
+            bytes: [
+                0x00, 0x00, 0x00, 0x03, // len:3
+                0x00, 0x01
+            ],
+            error: {
+                type: 'bufrw.short-buffer',
+                name: 'BufrwShortBufferError',
+                message: 'expected at least 3 bytes, only have 2 @[0:4]'
+            }
+        }
+    }
 
-    test('ThriftBinary', testThrift(ThriftBinary, BinaryRW, TYPE.STRING));
-}
+]));
+
+test('ThriftBinary', testThrift(ThriftBinary, BinaryRW, TYPE.STRING));

--- a/test/boolean.js
+++ b/test/boolean.js
@@ -20,39 +20,36 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var testThrift = require('./thrift-test');
+var invalidArgumentTestCase = require('./helpers').invalidArgumentTestCase;
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var testThrift = require('./thrift-test');
-    var invalidArgumentTestCase = require('./helpers').invalidArgumentTestCase;
+var thriftrw = require('../index');
+var BooleanRW = thriftrw.BooleanRW;
+var ThriftBoolean = thriftrw.ThriftBoolean;
+var TYPE = require('../TYPE');
 
-    var thriftrw = require('../index');
-    var BooleanRW = thriftrw.BooleanRW;
-    var ThriftBoolean = thriftrw.ThriftBoolean;
-    var TYPE = require('../TYPE');
+var validTestCases = [
+    [false, [0x00]],
+    [true, [0x01]]
+];
 
-    var validTestCases = [
-        [false, [0x00]],
-        [true, [0x01]]
-    ];
+var invalidArgumentTestCases = [
+    null,
+    undefined,
+    1,
+    0x00,
+    0x01,
+    0x02,
+    [],
+    {}
+].map(invalidArgumentTestCase('boolean'));
 
-    var invalidArgumentTestCases = [
-        null,
-        undefined,
-        1,
-        0x00,
-        0x01,
-        0x02,
-        [],
-        {}
-    ].map(invalidArgumentTestCase('boolean'));
+var testCases = [].concat(
+    validTestCases,
+    invalidArgumentTestCases
+);
 
-    var testCases = [].concat(
-        validTestCases,
-        invalidArgumentTestCases
-    );
-
-    test('BooleanRW', testRW.cases(BooleanRW, testCases));
-    test('ThriftBoolean', testThrift(ThriftBoolean, BooleanRW, TYPE.BOOL));
-}
+test('BooleanRW', testRW.cases(BooleanRW, testCases));
+test('ThriftBoolean', testThrift(ThriftBoolean, BooleanRW, TYPE.BOOL));

--- a/test/const.js
+++ b/test/const.js
@@ -20,21 +20,20 @@
 
 'use strict';
 
+var test = require('tape');
+
+var Thrift = require('..').Thrift;
 var fs = require('fs');
 var path = require('path');
 var source = fs.readFileSync(path.join(__dirname, 'const.thrift'), 'ascii');
-var withLoader = require('./loader');
+var thrift;
 
-withLoader(function(loadThrift, test) {
-    test('consts parse', function t(assert) {
-        loadThrift({source: source}, function (err, thrift) {
-            assert.ifError(err);
-            assert.equal(thrift.consts.ten, 10, 'ten constant');
-            assert.equal(thrift.consts.tenForward, 10, 'forward reference');
-            assert.deepEqual(thrift.consts.edges, {0: 1, 1: 2}, 'map constant');
-            assert.deepEqual(thrift.consts.names, ['a', 'ab', 'abc'], 'list constant');
-            assert.deepEqual(thrift.consts.tens, [10, 10, 10], 'list of identifiers');
-            assert.end();
-        });
-    });
+test('consts parse', function t(assert) {
+    thrift = new Thrift({source: source});
+    assert.equal(thrift.consts.ten, 10, 'ten constant');
+    assert.equal(thrift.consts.tenForward, 10, 'forward reference');
+    assert.deepEqual(thrift.consts.edges, {0: 1, 1: 2}, 'map constant');
+    assert.deepEqual(thrift.consts.names, ['a', 'ab', 'abc'], 'list constant');
+    assert.deepEqual(thrift.consts.tens, [10, 10, 10], 'list of identifiers');
+    assert.end();
 });

--- a/test/const.js
+++ b/test/const.js
@@ -20,16 +20,15 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var fs = require('fs');
+var path = require('path');
+var source = fs.readFileSync(path.join(__dirname, 'const.thrift'), 'ascii');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-
-    var fs = require('fs');
-    var path = require('path');
-    var source = fs.readFileSync(path.join(__dirname, 'const.thrift'), 'ascii');
-
+withLoader(function(loadThrift, test) {
     test('consts parse', function t(assert) {
         loadThrift({source: source}, function (err, thrift) {
+            assert.ifError(err);
             assert.equal(thrift.consts.ten, 10, 'ten constant');
             assert.equal(thrift.consts.tenForward, 10, 'forward reference');
             assert.deepEqual(thrift.consts.edges, {0: 1, 1: 2}, 'map constant');
@@ -38,4 +37,4 @@ module.exports = function(loadThrift) {
             assert.end();
         });
     });
-}
+});

--- a/test/default.js
+++ b/test/default.js
@@ -20,51 +20,42 @@
 
 'use strict';
 
-var withLoader = require('./loader');
+var test = require('tape');
 
+var Thrift = require('..').Thrift;
 var fs = require('fs');
 var path = require('path');
 var entryIdl = path.join(__dirname, 'default.thrift');
+var model;
 
-withLoader(function(loadThrift, test) {
+var allowFilesystemAccess = !process.browser;
+var idls;
+if (process.browser) {
+    idls = global.idls;
+}
 
-    var allowFilesystemAccess = !process.browser;
-    var idls;
-    if (process.browser) {
-        idls = global.idls;
-    }
+test('default values on structs work', function t(assert) {
+    model = new Thrift({entryPoint: entryIdl, allowFilesystemAccess: allowFilesystemAccess, idls: idls});
+    var health = new model.Health({name: 'grand'});
+    assert.equals(health.ok, true, 'default truth value passes through');
+    assert.equals(health.notOk, false, 'default false value passes through');
+    assert.equals(health.message, 'OK', 'default string passes through');
+    assert.equals(health.name, 'grand', 'option overrides default');
+    assert.equals(health.respected, null, 'null is default value');
+    assert.equals(health.ragdoll, null, 'null is default value for dependent thrifts');
+    assert.deepEquals(health.numbers, [1, 2, 3], 'complex defaults serialize');
+    assert.end();
+});
 
-    test('default values on structs work', function t(assert) {
-        loadThrift({
-            entryPoint: entryIdl,
-            allowFilesystemAccess: allowFilesystemAccess,
-            idls: idls
-        }, function (err, model) {
-            assert.ifError(err);
-            var health = new model.Health({name: 'grand'});
-            assert.equals(health.ok, true, 'default truth value passes through');
-            assert.equals(health.notOk, false, 'default false value passes through');
-            assert.equals(health.message, 'OK', 'default string passes through');
-            assert.equals(health.name, 'grand', 'option overrides default');
-            assert.equals(health.respected, null, 'null is default value');
-            assert.equals(health.ragdoll, null, 'null is default value for dependent thrifts');
-            assert.deepEquals(health.numbers, [1, 2, 3], 'complex defaults serialize');
-            assert.end();
-        });
+test('default value as undefined respected in constructor', function t(assert) {
+    model = new Thrift({
+        entryPoint: entryIdl,
+        allowFilesystemAccess: allowFilesystemAccess,
+        defaultAsUndefined: true,
+        idls: idls
     });
-
-    test('default value as undefined respected in constructor', function t(assert) {
-        loadThrift({
-            entryPoint: entryIdl,
-            allowFilesystemAccess: allowFilesystemAccess,
-            defaultAsUndefined: true,
-            idls: idls
-        }, function (err, model) {
-            var health = new model.Health({name: 'grand'});
-            assert.equals(health.respected, undefined, 'undefined as default value');
-            assert.equals(health.ragdoll, undefined, 'undefined as default value for dependent thrifts');
-            assert.end();
-        });
-    });
-
+    var health = new model.Health({name: 'grand'});
+    assert.equals(health.respected, undefined, 'undefined as default value');
+    assert.equals(health.ragdoll, undefined, 'undefined as default value for dependent thrifts');
+    assert.end();
 });

--- a/test/default.js
+++ b/test/default.js
@@ -20,13 +20,13 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var withLoader = require('./loader');
 
-    var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var entryIdl = path.join(__dirname, 'default.thrift');
 
-    var fs = require('fs');
-    var path = require('path');
-    var entryIdl = path.join(__dirname, 'default.thrift');
+withLoader(function(loadThrift, test) {
 
     var allowFilesystemAccess = !process.browser;
     var idls;
@@ -40,6 +40,7 @@ module.exports = function(loadThrift) {
             allowFilesystemAccess: allowFilesystemAccess,
             idls: idls
         }, function (err, model) {
+            assert.ifError(err);
             var health = new model.Health({name: 'grand'});
             assert.equals(health.ok, true, 'default truth value passes through');
             assert.equals(health.notOk, false, 'default false value passes through');
@@ -65,4 +66,5 @@ module.exports = function(loadThrift) {
             assert.end();
         });
     });
-}
+
+});

--- a/test/double.js
+++ b/test/double.js
@@ -20,30 +20,27 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var testThrift = require('./thrift-test');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var testThrift = require('./thrift-test');
+var thriftrw = require('../index');
+var DoubleRW = thriftrw.DoubleRW;
+var ThriftDouble = thriftrw.ThriftDouble;
+var TYPE = require('../TYPE');
 
-    var thriftrw = require('../index');
-    var DoubleRW = thriftrw.DoubleRW;
-    var ThriftDouble = thriftrw.ThriftDouble;
-    var TYPE = require('../TYPE');
+/*eslint-disable space-in-brackets*/
+var validTestCases = [
+    // Thrift is Big Endian
+    [-1, [0xbf, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]],
+    [ 0, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]],
+    [ 1, [0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]]
+];
+/*eslint-enable space-in-brackets*/
 
-    /*eslint-disable space-in-brackets*/
-    var validTestCases = [
-        // Thrift is Big Endian
-        [-1, [0xbf, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]],
-        [ 0, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]],
-        [ 1, [0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]]
-    ];
-    /*eslint-enable space-in-brackets*/
+var testCases = [].concat(
+    validTestCases
+);
 
-    var testCases = [].concat(
-        validTestCases
-    );
-
-    test('DoubleRW', testRW.cases(DoubleRW, testCases));
-    test('ThriftDouble', testThrift(ThriftDouble, DoubleRW, TYPE.DOUBLE));
-}
+test('DoubleRW', testRW.cases(DoubleRW, testCases));
+test('ThriftDouble', testThrift(ThriftDouble, DoubleRW, TYPE.DOUBLE));

--- a/test/enum.js
+++ b/test/enum.js
@@ -23,14 +23,18 @@
 /* eslint no-new:[0] */
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var fs = require('fs');
-    var path = require('path');
+withLoader(function (loadThrift, test) {
 
     var source = fs.readFileSync(path.join(__dirname, 'enum.thrift'), 'ascii');
     loadThrift({source: source}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
         var MyStruct = thrift.getType('MyStruct');
 
         test('can access enum def annotations', function t(assert) {
@@ -144,4 +148,5 @@ module.exports = function(loadThrift) {
             assert.end();
         });
     });
-}
+
+});

--- a/test/exception.js
+++ b/test/exception.js
@@ -24,60 +24,53 @@ var test = require('tape');
 var testRW = require('bufrw/test_rw');
 var fs = require('fs');
 var path = require('path');
-var withLoader = require('./loader');
+var Thrift = require('../thrift').Thrift;
 
-withLoader(function (loadThrift, test) {
+var source = fs.readFileSync(path.join(__dirname, 'exception.thrift'), 'ascii');
+var thrift = new Thrift({source: source});
 
-    var source = fs.readFileSync(path.join(__dirname, 'exception.thrift'), 'ascii');
-    loadThrift({source: source}, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
-        var err = new thrift.BogusNameError({message: 'Bogus name: Voldemort', bogusName: 'Voldemort'});
+var err = new thrift.BogusNameError({message: 'Bogus name: Voldemort', bogusName: 'Voldemort'});
 
-        test('Exception RW', testRW.cases(thrift.BogusNameError.rw, [
+test('Exception RW', testRW.cases(thrift.BogusNameError.rw, [
 
-            [err, [
-                0x0b,                         // typeid:1 -- 11, STRING
-                0x00, 0x01,                   // id:2     -- 1, bogusName
-                0x00, 0x00, 0x00, 0x09,       // length:4 -- 9
-                0x56, 0x6f, 0x6c, 0x64, 0x65, //          -- 'Voldemort'
-                0x6d, 0x6f, 0x72, 0x74,       //
-                0x0b,                         // typeid:1 -- 11, STRING
-                0x00, 0x02,                   // id:2     -- 2, message
-                0x00, 0x00, 0x00, 0x15,       // lenght:4 -- 21
-                0x42, 0x6f, 0x67, 0x75, 0x73,
-                0x20, 0x6e, 0x61, 0x6d, 0x65,
-                0x3a, 0x20, 0x56, 0x6f, 0x6c,
-                0x64, 0x65, 0x6d, 0x6f, 0x72,
-                0x74,
-                0x00                          // typeid:1 -- 0, STOP
-            ]]
+    [err, [
+        0x0b,                         // typeid:1 -- 11, STRING
+        0x00, 0x01,                   // id:2     -- 1, bogusName
+        0x00, 0x00, 0x00, 0x09,       // length:4 -- 9
+        0x56, 0x6f, 0x6c, 0x64, 0x65, //          -- 'Voldemort'
+        0x6d, 0x6f, 0x72, 0x74,       //
+        0x0b,                         // typeid:1 -- 11, STRING
+        0x00, 0x02,                   // id:2     -- 2, message
+        0x00, 0x00, 0x00, 0x15,       // lenght:4 -- 21
+        0x42, 0x6f, 0x67, 0x75, 0x73,
+        0x20, 0x6e, 0x61, 0x6d, 0x65,
+        0x3a, 0x20, 0x56, 0x6f, 0x6c,
+        0x64, 0x65, 0x6d, 0x6f, 0x72,
+        0x74,
+        0x00                          // typeid:1 -- 0, STOP
+    ]]
 
-        ]));
+]));
 
-        var err2 = new thrift.BogusWithType({message: 'Bogus name: Voldemort', type: 'Voldemort'});
+var err2 = new thrift.BogusWithType({message: 'Bogus name: Voldemort', type: 'Voldemort'});
 
-        test('Exception RW with type', testRW.cases(thrift.BogusWithType.rw, [
+test('Exception RW with type', testRW.cases(thrift.BogusWithType.rw, [
 
-            [err2, [
-                0x0b,                         // typeid:1 -- 11, STRING
-                0x00, 0x01,                   // id:2     -- 1, type
-                0x00, 0x00, 0x00, 0x09,       // length:4 -- 9
-                0x56, 0x6f, 0x6c, 0x64, 0x65, //          -- 'Voldemort'
-                0x6d, 0x6f, 0x72, 0x74,       //
-                0x0b,                         // typeid:1 -- 11, STRING
-                0x00, 0x02,                   // id:2     -- 2, message
-                0x00, 0x00, 0x00, 0x15,       // lenght:4 -- 21
-                0x42, 0x6f, 0x67, 0x75, 0x73,
-                0x20, 0x6e, 0x61, 0x6d, 0x65,
-                0x3a, 0x20, 0x56, 0x6f, 0x6c,
-                0x64, 0x65, 0x6d, 0x6f, 0x72,
-                0x74,
-                0x00                          // typeid:1 -- 0, STOP
-            ]]
+    [err2, [
+        0x0b,                         // typeid:1 -- 11, STRING
+        0x00, 0x01,                   // id:2     -- 1, type
+        0x00, 0x00, 0x00, 0x09,       // length:4 -- 9
+        0x56, 0x6f, 0x6c, 0x64, 0x65, //          -- 'Voldemort'
+        0x6d, 0x6f, 0x72, 0x74,       //
+        0x0b,                         // typeid:1 -- 11, STRING
+        0x00, 0x02,                   // id:2     -- 2, message
+        0x00, 0x00, 0x00, 0x15,       // lenght:4 -- 21
+        0x42, 0x6f, 0x67, 0x75, 0x73,
+        0x20, 0x6e, 0x61, 0x6d, 0x65,
+        0x3a, 0x20, 0x56, 0x6f, 0x6c,
+        0x64, 0x65, 0x6d, 0x6f, 0x72,
+        0x74,
+        0x00                          // typeid:1 -- 0, STOP
+    ]]
 
-        ]));
-    });
-
-});
+]));

--- a/test/exception.js
+++ b/test/exception.js
@@ -20,15 +20,19 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var fs = require('fs');
-    var path = require('path');
+withLoader(function (loadThrift, test) {
 
     var source = fs.readFileSync(path.join(__dirname, 'exception.thrift'), 'ascii');
     loadThrift({source: source}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
         var err = new thrift.BogusNameError({message: 'Bogus name: Voldemort', bogusName: 'Voldemort'});
 
         test('Exception RW', testRW.cases(thrift.BogusNameError.rw, [
@@ -75,4 +79,5 @@ module.exports = function(loadThrift) {
 
         ]));
     });
-}
+
+});

--- a/test/i16.js
+++ b/test/i16.js
@@ -20,72 +20,69 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var testThrift = require('./thrift-test');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var testThrift = require('./thrift-test');
+var thriftrw = require('../index');
+var I16RW = thriftrw.I16RW;
+var ThriftI16 = thriftrw.ThriftI16;
+var TYPE = require('../TYPE');
 
-    var thriftrw = require('../index');
-    var I16RW = thriftrw.I16RW;
-    var ThriftI16 = thriftrw.ThriftI16;
-    var TYPE = require('../TYPE');
+/*eslint-disable space-in-brackets,no-multi-spaces*/
+var testCases = [
+    [-0x1234, [0xed, 0xcc]],
+    [      0, [0x00, 0x00]],
+    [ 0x1234, [0x12, 0x34]],
 
-    /*eslint-disable space-in-brackets,no-multi-spaces*/
-    var testCases = [
-        [-0x1234, [0xed, 0xcc]],
-        [      0, [0x00, 0x00]],
-        [ 0x1234, [0x12, 0x34]],
-
-        {
-            writeTest: {
-                value: '10',
-                bytes: [0x00, 0x0a]
-            }
-        },
-        {
-            writeTest: {
-                value: 0xffff,
-                bytes: [0xff, 0xff],
-                error: {
-                    message: 'value 65535 out of range, min: -32768 max: 32767',
-                    name: 'BufrwRangeErrorError',
-                    type: 'bufrw.range-error'
-                }
-            }
-        },
-
-        {
-            readTest: {
-                bytes: [],
-                error: {
-                    // message: 'short read, 4 bytes needed after consuming 0'
-                    // TODO validate message (currently incorrect)
-                    name: 'BufrwShortReadError',
-                    type: 'bufrw.short-read'
-                }
-            }
-        },
-
-        {
-            writeTest: {
-                value: '+255',
-                bytes: [0x00, 0xff]
-            }
-        },
-        {
-            writeTest: {
-                value: 'hello',
-                error: {
-                    type: 'bufrw.invalid-argument',
-                    name: 'BufrwInvalidArgumentError',
-                    message: 'invalid argument, expected a number'
-                }
+    {
+        writeTest: {
+            value: '10',
+            bytes: [0x00, 0x0a]
+        }
+    },
+    {
+        writeTest: {
+            value: 0xffff,
+            bytes: [0xff, 0xff],
+            error: {
+                message: 'value 65535 out of range, min: -32768 max: 32767',
+                name: 'BufrwRangeErrorError',
+                type: 'bufrw.range-error'
             }
         }
-    ];
-    /*eslint-enable space-in-brackets,no-multi-spaces*/
+    },
 
-    test('I16RW', testRW.cases(new I16RW(), testCases));
-    test('ThriftI16', testThrift(ThriftI16, ThriftI16.prototype.rw, TYPE.I16));
-}
+    {
+        readTest: {
+            bytes: [],
+            error: {
+                // message: 'short read, 4 bytes needed after consuming 0'
+                // TODO validate message (currently incorrect)
+                name: 'BufrwShortReadError',
+                type: 'bufrw.short-read'
+            }
+        }
+    },
+
+    {
+        writeTest: {
+            value: '+255',
+            bytes: [0x00, 0xff]
+        }
+    },
+    {
+        writeTest: {
+            value: 'hello',
+            error: {
+                type: 'bufrw.invalid-argument',
+                name: 'BufrwInvalidArgumentError',
+                message: 'invalid argument, expected a number'
+            }
+        }
+    }
+];
+/*eslint-enable space-in-brackets,no-multi-spaces*/
+
+test('I16RW', testRW.cases(new I16RW(), testCases));
+test('ThriftI16', testThrift(ThriftI16, ThriftI16.prototype.rw, TYPE.I16));

--- a/test/i32.js
+++ b/test/i32.js
@@ -20,83 +20,80 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var thriftTest = require('./thrift-test');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var thriftTest = require('./thrift-test');
+var thriftrw = require('../index');
+var I32RW = thriftrw.I32RW;
+var ThriftI32 = thriftrw.ThriftI32;
+var TYPE = require('../TYPE');
 
-    var thriftrw = require('../index');
-    var I32RW = thriftrw.I32RW;
-    var ThriftI32 = thriftrw.ThriftI32;
-    var TYPE = require('../TYPE');
+/*eslint-disable space-in-brackets*/
+var testCases = [
+    [-0x12345678, [0xed, 0xcb, 0xa9, 0x88]],
+    [ 0x00000000, [0x00, 0x00, 0x00, 0x00]],
+    [ 0x12345678, [0x12, 0x34, 0x56, 0x78]],
 
-    /*eslint-disable space-in-brackets*/
-    var testCases = [
-        [-0x12345678, [0xed, 0xcb, 0xa9, 0x88]],
-        [ 0x00000000, [0x00, 0x00, 0x00, 0x00]],
-        [ 0x12345678, [0x12, 0x34, 0x56, 0x78]],
+    {
+        writeTest: {
+            value: '10',
+            bytes: [0x00, 0x00, 0x00, 0x0a]
+        }
+    },
+    {
+        writeTest: {
+            value: '+255',
+            bytes: [0x00, 0x00, 0x00, 0xff]
+        }
+    },
 
-        {
-            writeTest: {
-                value: '10',
-                bytes: [0x00, 0x00, 0x00, 0x0a]
-            }
-        },
-        {
-            writeTest: {
-                value: '+255',
-                bytes: [0x00, 0x00, 0x00, 0xff]
-            }
-        },
-
-        {
-            readTest: {
-                bytes: [],
-                error: {
-                    message: 'short read, 0 byte left over after consuming 0',
-                    name: 'BufrwShortReadError',
-                    type: 'bufrw.short-read'
-                }
-            }
-        },
-
-        {
-            readTest: {
-                bytes: [0, 0, 0],
-                error: {
-                    message: 'short read, 3 byte left over after consuming 0',
-                    name: 'BufrwShortReadError',
-                    type: 'bufrw.short-read'
-                }
-            }
-        },
-
-
-        {
-            writeTest: {
-                value: 0xffffffff,
-                bytes: [0xff, 0xff, 0xff, 0xff],
-                error: {
-                    message: 'value 4294967295 out of range, min: -2147483648 max: 2147483647',
-                    name: 'BufrwRangeErrorError',
-                    type: 'bufrw.range-error'
-                }
-            }
-        },
-        {
-            writeTest: {
-                value: 'hello',
-                error: {
-                    type: 'bufrw.invalid-argument',
-                    name: 'BufrwInvalidArgumentError',
-                    message: 'invalid argument, expected a number'
-                }
+    {
+        readTest: {
+            bytes: [],
+            error: {
+                message: 'short read, 0 byte left over after consuming 0',
+                name: 'BufrwShortReadError',
+                type: 'bufrw.short-read'
             }
         }
-    ];
-    /*eslint-enable space-in-brackets*/
+    },
 
-    test('I32RW', testRW.cases(new I32RW(), testCases));
-    test('ThriftI32', thriftTest(ThriftI32, ThriftI32.prototype.rw, TYPE.I32));
-}
+    {
+        readTest: {
+            bytes: [0, 0, 0],
+            error: {
+                message: 'short read, 3 byte left over after consuming 0',
+                name: 'BufrwShortReadError',
+                type: 'bufrw.short-read'
+            }
+        }
+    },
+
+
+    {
+        writeTest: {
+            value: 0xffffffff,
+            bytes: [0xff, 0xff, 0xff, 0xff],
+            error: {
+                message: 'value 4294967295 out of range, min: -2147483648 max: 2147483647',
+                name: 'BufrwRangeErrorError',
+                type: 'bufrw.range-error'
+            }
+        }
+    },
+    {
+        writeTest: {
+            value: 'hello',
+            error: {
+                type: 'bufrw.invalid-argument',
+                name: 'BufrwInvalidArgumentError',
+                message: 'invalid argument, expected a number'
+            }
+        }
+    }
+];
+/*eslint-enable space-in-brackets*/
+
+test('I32RW', testRW.cases(new I32RW(), testCases));
+test('ThriftI32', thriftTest(ThriftI32, ThriftI32.prototype.rw, TYPE.I32));

--- a/test/i64.js
+++ b/test/i64.js
@@ -20,22 +20,26 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var Long = require('long');
+var testRW = require('bufrw/test_rw');
+var testThrift = require('./thrift-test');
+var thriftrw = require('../index');
+var ThriftI64 = thriftrw.ThriftI64;
+var TYPE = require('../TYPE');
+var Buffer = require('buffer').Buffer;
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var fs = require('fs');
-    var path = require('path');
-    var Long = require('long');
-    var testRW = require('bufrw/test_rw');
-    var testThrift = require('./thrift-test');
-    var thriftrw = require('../index');
-    var ThriftI64 = thriftrw.ThriftI64;
-    var TYPE = require('../TYPE');
-    var Buffer = require('buffer').Buffer;
+withLoader(function (loadThrift, test) {
 
     loadThrift({
         source: fs.readFileSync(path.join(__dirname, 'i64.thrift'), 'ascii')
     }, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
 
         var bufferRW = thrift.getType('bufnum').rw;
         var longRW = thrift.getType('long').rw;
@@ -302,4 +306,5 @@ module.exports = function(loadThrift) {
         test('ThriftI64', testThrift(ThriftI64, bufferRW, TYPE.I64));
 
     });
-}
+
+});

--- a/test/i64.js
+++ b/test/i64.js
@@ -30,281 +30,268 @@ var thriftrw = require('../index');
 var ThriftI64 = thriftrw.ThriftI64;
 var TYPE = require('../TYPE');
 var Buffer = require('buffer').Buffer;
-var withLoader = require('./loader');
 
-withLoader(function (loadThrift, test) {
-
-    loadThrift({
-        source: fs.readFileSync(path.join(__dirname, 'i64.thrift'), 'ascii')
-    }, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
-
-        var bufferRW = thrift.getType('bufnum').rw;
-        var longRW = thrift.getType('long').rw;
-        var dateRW = thrift.getType('timestamp').rw;
-
-        var bufferCases = [
-            [
-                Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
-                [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
-                {
-                    readTest: {
-                        bytes: [],
-                        error: {
-                            type: 'bufrw.short-read',
-                            name: 'BufrwShortReadError',
-                            message: 'short read, 0 byte left over after consuming 0'
-                        },
-                    },
-                    writeTest: {
-                        bytes: [],
-                        value: 0,
-                        error: {
-                            type: 'bufrw.short-buffer',
-                            name: 'BufrwShortBufferError',
-                            message: 'expected at least 8 bytes, only have 0 @0'
-                        }
-                    },
-                },
-            ]
-        ];
-
-        test('I64BufferRW', testRW.cases(bufferRW, bufferCases));
-
-        var longCases = [
-            [
-                Long.fromNumber(Math.pow(2, 53) - 1),
-                [0x00, 0x1f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
-                {
-                    readTest: {
-                        bytes: [],
-                        error: {
-                            type: 'bufrw.short-read',
-                            name: 'BufrwShortReadError',
-                            message: 'short read, 0 byte left over after consuming 0'
-                        },
-                    },
-                },
-                {
-                    writeTest: {
-                        bytes: [],
-                        value: 0,
-                        error: {
-                            type: 'bufrw.short-buffer',
-                            name: 'BufrwShortBufferError',
-                            message: 'expected at least 8 bytes, only have 0 @0'
-                        }
-                    },
-                },
-                {
-                    writeTest: {
-                        bytes: [],
-                        value: {hi: 0, lo: 0},
-                        error: {
-                            type: 'bufrw.short-buffer',
-                            name: 'BufrwShortBufferError',
-                            message: 'expected at least 8 bytes, only have 0 @0'
-                        }
-                    },
-                },
-            ]
-        ];
-
-        test('I64LongRW negatives', function t(assert) {
-            var buffer = new Buffer(8);
-            longRW.poolWriteInto({
-                reset: function (val, err) {}
-            }, -1, buffer, 0);
-            assert.deepEquals(buffer, new Buffer('ffffffffffffffff', 'hex'), 'writen value is negative');
-            assert.end();
-        });
-
-        test('I64LongRW', testRW.cases(longRW, longCases));
-
-        var dateCases = [
-            [
-                new Date(0),
-                [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-            ],
-            [
-                new Date(1),
-                [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]
-            ],
-            [
-                new Date(1000),
-                [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xe8]
-            ],
-            {
-                readTest: {
-                    bytes: [],
-                    error: {
-                        type: 'bufrw.short-read',
-                        name: 'BufrwShortReadError',
-                        message: 'short read, 0 byte left over after consuming 0'
-                    },
-                },
-            },
-            {
-                writeTest: {
-                    bytes: [],
-                    value: new Date(),
-                    error: {
-                        type: 'bufrw.short-buffer',
-                        name: 'BufrwShortBufferError',
-                        message: 'expected at least 8 bytes, only have 0 @0'
-                    }
-                },
-            },
-        ];
-
-        test('I64DateRW', testRW.cases(dateRW, dateCases));
-
-        test('coerce string', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto('0102030405060708', buffer, 0);
-            assert.ifError(res.err, 'write into buffer');
-            assert.equals(res.offset, 8, 'offset after write');
-            assert.deepEquals(buffer, new Buffer('0102030405060708', 'hex'), 'written value');
-            assert.end();
-        });
-
-        test('fail to coerce string of bad length', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto('01020304050607', buffer, 0);
-            assert.equals(
-                res.err.message,
-                'invalid argument, expected a string of 16 hex characters, or other i64 representation',
-                'string length error'
-            );
-            assert.end();
-        });
-
-        test('fail to coerce string of bad hi value', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto('--------05060708', buffer, 0);
-            assert.equals(
-                res.err.message,
-                'invalid argument, expected a string of hex characters, or other i64 representation',
-                'validate hi string value');
-            assert.end();
-        });
-
-        test('fail to coerce string of bad lo value', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto('01020304--------', buffer, 0);
-            assert.equals(res.err.message,
-                'invalid argument, expected a string of hex characters, or other i64 representation',
-                'validate lo string value');
-            assert.end();
-        });
-
-        test('coerce {hi[gh], lo[w]} object to i32 on wire', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto({hi: 1, lo: 2}, buffer, 0);
-            assert.ifError(res.err, 'write into buffer');
-            assert.equals(res.offset, 8, 'offset after write');
-            assert.deepEquals(buffer, new Buffer('0000000100000002', 'hex'), 'wrote hi[gh], lo[w] to buffer');
-            assert.end();
-        });
-
-        test('fail to coerce object bad hi value', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto({hi: null, lo: 0}, buffer, 0);
-            assert.equals(res.err.message,
-                'invalid argument, expected {hi[gh], lo[w]} with high bits, or other i64 representation',
-                'validate hi type');
-            assert.end();
-        });
-
-        test('fail to coerce object bad lo value', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto({hi: 0, lo: null}, buffer, 0);
-            assert.equals(res.err.message,
-                'invalid argument, expected {hi[gh], lo[w]} with low bits, or other i64 representation',
-                'validate lo type');
-            assert.end();
-        });
-
-        test('coerce small number', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto(10, buffer, 0);
-            assert.ifError(res.err, 'write into buffer');
-            assert.equals(res.offset, 8, 'offset after write');
-            assert.deepEquals(buffer, new Buffer('000000000000000a', 'hex'), 'written value');
-            assert.end();
-        });
-
-        test('coerce large number', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto(Math.pow(2, 50), buffer, 0);
-            assert.ifError(res.err, 'write into buffer');
-            assert.equals(res.offset, 8, 'offset after write');
-            assert.deepEquals(buffer, new Buffer('0004000000000000', 'hex'), 'written value');
-            assert.end();
-        });
-
-        test('coerce array of bytes', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto([1, 2, 3, 4, 5, 6, 7, 8], buffer, 0);
-            assert.ifError(res.err, 'write into buffer');
-            assert.equals(res.offset, 8, 'offset after write');
-            assert.deepEquals(buffer, new Buffer('0102030405060708', 'hex'), 'written value');
-            assert.end();
-        });
-
-        test('fail to coerce array with bad length', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto([1, 2, 3, 4, 5, 6, 7, 8, 9], buffer, 0);
-            assert.equals(res.err.message,
-                'invalid argument, expected an array of 8 bytes, or other i64 representation',
-                'validate buffer length');
-            assert.end();
-        });
-
-        test('fail to coerce', function t(assert) {
-            var buffer = new Buffer(8);
-            var res = bufferRW.writeInto(null, buffer, 0);
-            assert.equals(res.err.message, 'invalid argument, expected i64 representation');
-            assert.end();
-        });
-
-        test('coerce date string', function t(assert) {
-            var buffer = new Buffer(8);
-            buffer.fill(0xff);
-            dateRW.writeInto('1970-01-01T00:00:00.000Z', buffer, 0);
-            assert.deepEquals(buffer, new Buffer([0, 0, 0, 0, 0, 0, 0, 0]), 'coerces date string');
-            assert.end();
-        });
-
-        test('coerce number to date', function t(assert) {
-            var buffer = new Buffer(8);
-            dateRW.writeInto(0, buffer, 0);
-            assert.deepEquals(buffer, new Buffer([0, 0, 0, 0, 0, 0, 0, 0]), 'coerces number to date');
-            assert.end();
-        });
-
-        test('Accepts buffer as date', function t(assert) {
-            var outBuffer = new Buffer(8);
-            outBuffer.fill(0xff);
-            var inbuffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8]);
-            dateRW.writeInto(inbuffer, outBuffer, 0);
-            assert.deepEquals(outBuffer, inbuffer, 'accepts date buffer');
-            assert.end();
-        });
-
-        test('Accepts array as date', function t(assert) {
-            var outBuffer = new Buffer(8);
-            outBuffer.fill(0xff);
-            var inArray = [1, 2, 3, 4, 5, 6, 7, 8];
-            dateRW.writeInto(inArray, outBuffer, 0);
-            assert.deepEquals(outBuffer, new Buffer(inArray), 'accepts date buffer');
-            assert.end();
-        });
-
-        test('ThriftI64', testThrift(ThriftI64, bufferRW, TYPE.I64));
-
-    });
-
+var thrift = new thriftrw.Thrift({
+    source: fs.readFileSync(path.join(__dirname, 'i64.thrift'), 'ascii')
 });
+
+var bufferRW = thrift.getType('bufnum').rw;
+var longRW = thrift.getType('long').rw;
+var dateRW = thrift.getType('timestamp').rw;
+
+var bufferCases = [
+    [
+        Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
+        [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
+        {
+            readTest: {
+                bytes: [],
+                error: {
+                    type: 'bufrw.short-read',
+                    name: 'BufrwShortReadError',
+                    message: 'short read, 0 byte left over after consuming 0'
+                },
+            },
+            writeTest: {
+                bytes: [],
+                value: 0,
+                error: {
+                    type: 'bufrw.short-buffer',
+                    name: 'BufrwShortBufferError',
+                    message: 'expected at least 8 bytes, only have 0 @0'
+                }
+            },
+        },
+    ]
+];
+
+test('I64BufferRW', testRW.cases(bufferRW, bufferCases));
+
+var longCases = [
+    [
+        Long.fromNumber(Math.pow(2, 53) - 1),
+        [0x00, 0x1f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+        {
+            readTest: {
+                bytes: [],
+                error: {
+                    type: 'bufrw.short-read',
+                    name: 'BufrwShortReadError',
+                    message: 'short read, 0 byte left over after consuming 0'
+                },
+            },
+        },
+        {
+            writeTest: {
+                bytes: [],
+                value: 0,
+                error: {
+                    type: 'bufrw.short-buffer',
+                    name: 'BufrwShortBufferError',
+                    message: 'expected at least 8 bytes, only have 0 @0'
+                }
+            },
+        },
+        {
+            writeTest: {
+                bytes: [],
+                value: {hi: 0, lo: 0},
+                error: {
+                    type: 'bufrw.short-buffer',
+                    name: 'BufrwShortBufferError',
+                    message: 'expected at least 8 bytes, only have 0 @0'
+                }
+            },
+        },
+    ]
+];
+
+test('I64LongRW negatives', function t(assert) {
+    var buffer = new Buffer(8);
+    longRW.poolWriteInto({
+        reset: function (val, err) {}
+    }, -1, buffer, 0);
+    assert.deepEquals(buffer, new Buffer('ffffffffffffffff', 'hex'), 'writen value is negative')
+    assert.end();
+});
+
+test('I64LongRW', testRW.cases(longRW, longCases));
+
+var dateCases = [
+    [
+        new Date(0),
+        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+    ],
+    [
+        new Date(1),
+        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]
+    ],
+    [
+        new Date(1000),
+        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xe8]
+    ],
+    {
+        readTest: {
+            bytes: [],
+            error: {
+                type: 'bufrw.short-read',
+                name: 'BufrwShortReadError',
+                message: 'short read, 0 byte left over after consuming 0'
+            },
+        },
+    },
+    {
+        writeTest: {
+            bytes: [],
+            value: new Date(),
+            error: {
+                type: 'bufrw.short-buffer',
+                name: 'BufrwShortBufferError',
+                message: 'expected at least 8 bytes, only have 0 @0'
+            }
+        },
+    },
+];
+
+test('I64DateRW', testRW.cases(dateRW, dateCases));
+
+test('coerce string', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto('0102030405060708', buffer, 0);
+    assert.ifError(res.err, 'write into buffer');
+    assert.equals(res.offset, 8, 'offset after write');
+    assert.deepEquals(buffer, new Buffer('0102030405060708', 'hex'), 'written value');
+    assert.end();
+});
+
+test('fail to coerce string of bad length', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto('01020304050607', buffer, 0);
+    assert.equals(res.err.message,
+        'invalid argument, expected a string of 16 hex characters, or other i64 representation', 'string length error');
+    assert.end();
+});
+
+test('fail to coerce string of bad hi value', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto('--------05060708', buffer, 0);
+    assert.equals(
+        res.err.message,
+        'invalid argument, expected a string of hex characters, or other i64 representation',
+        'validate hi string value');
+    assert.end();
+});
+
+test('fail to coerce string of bad lo value', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto('01020304--------', buffer, 0);
+    assert.equals(res.err.message,
+        'invalid argument, expected a string of hex characters, or other i64 representation',
+        'validate lo string value');
+    assert.end();
+});
+
+test('coerce {hi[gh], lo[w]} object to i32 on wire', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto({hi: 1, lo: 2}, buffer, 0);
+    assert.ifError(res.err, 'write into buffer');
+    assert.equals(res.offset, 8, 'offset after write');
+    assert.deepEquals(buffer, new Buffer('0000000100000002', 'hex'), 'wrote hi[gh], lo[w] to buffer');
+    assert.end();
+});
+
+test('fail to coerce object bad hi value', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto({hi: null, lo: 0}, buffer, 0);
+    assert.equals(res.err.message,
+        'invalid argument, expected {hi[gh], lo[w]} with high bits, or other i64 representation',
+        'validate hi type');
+    assert.end();
+});
+
+test('fail to coerce object bad lo value', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto({hi: 0, lo: null}, buffer, 0);
+    assert.equals(res.err.message,
+        'invalid argument, expected {hi[gh], lo[w]} with low bits, or other i64 representation',
+        'validate lo type');
+    assert.end();
+});
+
+test('coerce small number', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto(10, buffer, 0);
+    assert.ifError(res.err, 'write into buffer');
+    assert.equals(res.offset, 8, 'offset after write');
+    assert.deepEquals(buffer, new Buffer('000000000000000a', 'hex'), 'written value');
+    assert.end();
+});
+
+test('coerce large number', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto(Math.pow(2, 50), buffer, 0);
+    assert.ifError(res.err, 'write into buffer');
+    assert.equals(res.offset, 8, 'offset after write');
+    assert.deepEquals(buffer, new Buffer('0004000000000000', 'hex'), 'written value');
+    assert.end();
+});
+
+test('coerce array of bytes', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto([1, 2, 3, 4, 5, 6, 7, 8], buffer, 0);
+    assert.ifError(res.err, 'write into buffer');
+    assert.equals(res.offset, 8, 'offset after write');
+    assert.deepEquals(buffer, new Buffer('0102030405060708', 'hex'), 'written value');
+    assert.end();
+});
+
+test('fail to coerce array with bad length', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto([1, 2, 3, 4, 5, 6, 7, 8, 9], buffer, 0);
+    assert.equals(res.err.message,
+        'invalid argument, expected an array of 8 bytes, or other i64 representation',
+        'validate buffer length');
+    assert.end();
+});
+
+test('fail to coerce', function t(assert) {
+    var buffer = new Buffer(8);
+    var res = bufferRW.writeInto(null, buffer, 0);
+    assert.equals(res.err.message, 'invalid argument, expected i64 representation');
+    assert.end();
+});
+
+test('coerce date string', function t(assert) {
+    var buffer = new Buffer(8);
+    buffer.fill(0xff);
+    dateRW.writeInto('1970-01-01T00:00:00.000Z', buffer, 0);
+    assert.deepEquals(buffer, new Buffer([0, 0, 0, 0, 0, 0, 0, 0]), 'coerces date string');
+    assert.end();
+});
+
+test('coerce number to date', function t(assert) {
+    var buffer = new Buffer(8);
+    dateRW.writeInto(0, buffer, 0);
+    assert.deepEquals(buffer, new Buffer([0, 0, 0, 0, 0, 0, 0, 0]), 'coerces number to date');
+    assert.end();
+});
+
+test('Accepts buffer as date', function t(assert) {
+    var outBuffer = new Buffer(8);
+    outBuffer.fill(0xff);
+    var inbuffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8]);
+    dateRW.writeInto(inbuffer, outBuffer, 0);
+    assert.deepEquals(outBuffer, inbuffer, 'accepts date buffer');
+    assert.end();
+});
+
+test('Accepts array as date', function t(assert) {
+    var outBuffer = new Buffer(8);
+    outBuffer.fill(0xff);
+    var inArray = [1, 2, 3, 4, 5, 6, 7, 8];
+    dateRW.writeInto(inArray, outBuffer, 0);
+    assert.deepEquals(outBuffer, new Buffer(inArray), 'accepts date buffer');
+    assert.end();
+});
+
+test('ThriftI64', testThrift(ThriftI64, bufferRW, TYPE.I64));

--- a/test/i8.js
+++ b/test/i8.js
@@ -23,7 +23,6 @@
 var test = require('tape');
 var testRW = require('bufrw/test_rw');
 var testThrift = require('./thrift-test');
-var withLoader = require('./loader');
 var invalidArgumentTestCase = require('./helpers').invalidArgumentTestCase;
 var path = require('path');
 var fs = require('fs');
@@ -129,14 +128,10 @@ var testCases = [].concat(
 test('I8RW', testRW.cases(ThriftI8.prototype.rw, testCases));
 test('ThriftI8', testThrift(ThriftI8, ThriftI8.prototype.rw, TYPE.I8));
 
-withLoader(function (loadThrift, test) {
-    test('Thrift i8 IDL', function t(assert) {
-        var source = fs.readFileSync(path.join(__dirname, 'i8.thrift'), 'ascii');
-        loadThrift({source: source}, function (err, thrift) {
-            assert.ifError(err);
-            assert.equal(thrift.typedefs.piecesOf8, Number, 'should surface a number');
-            assert.equal(thrift.models.piecesOf8.to.rw, ThriftI8.prototype.rw, 'should refer to I8 rw');
-            assert.end();
-        });
-    });
+test('Thrift i8 IDL', function t(assert) {
+    var source = fs.readFileSync(path.join(__dirname, 'i8.thrift'), 'ascii');
+    var thrift = new Thrift({source: source});
+    assert.equal(thrift.typedefs.piecesOf8, Number, 'should surface a number');
+    assert.equal(thrift.models.piecesOf8.to.rw, ThriftI8.prototype.rw, 'should refer to I8 rw');
+    assert.end();
 });

--- a/test/idls.js
+++ b/test/idls.js
@@ -20,17 +20,18 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var fs = require('fs');
-    var path = require('path');
+var allowFilesystemAccess = !process.browser;
+var idls;
+if (process.browser) {
+    idls = global.idls;
+}
 
-    var allowFilesystemAccess = !process.browser;
-    var idls;
-    if (process.browser) {
-        idls = global.idls;
-    }
+withLoader(function (loadThrift, test) {
 
     test('can round trip a thrift file through sources', function t(assert) {
         loadThrift({
@@ -40,12 +41,14 @@ module.exports = function(loadThrift) {
             allowIncludeAlias: true,
             idls: idls
         }, function (err, thrift) {
+            assert.ifError(err);
             var sources = thrift.getSources();
             loadThrift({
                 entryPoint: sources.entryPoint,
                 idls: sources.idls,
                 allowIncludeAlias: true
             }, function (err, rethrift) {
+                assert.ifError(err);
                 assert.deepEquals(
                     Object.keys(rethrift.models),
                     Object.keys(thrift.models),
@@ -55,4 +58,5 @@ module.exports = function(loadThrift) {
             });
         });
     });
-}
+
+});

--- a/test/include.js
+++ b/test/include.js
@@ -20,16 +20,18 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
 
-    var test = require('tape');
-    var path = require('path');
+var test = require('tape');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var allowFilesystemAccess = !process.browser;
-    var idls;
-    if (process.browser) {
-        idls = global.idls;
-    }
+var allowFilesystemAccess = !process.browser;
+var idls;
+if (process.browser) {
+    idls = global.idls;
+}
+
+withLoader(function (loadThrift, test) {
 
     test('loads a thrift file that imports synchronously', function t(assert) {
         loadThrift({
@@ -38,6 +40,8 @@ module.exports = function(loadThrift) {
             allowFilesystemAccess: allowFilesystemAccess,
             idls: idls
         }, function (err, mainThrift) {
+            assert.ifError(err);
+
             var importedThrift = mainThrift.modules.common;
 
             var typeImportedByMainThrift = mainThrift // Thrift
@@ -97,6 +101,7 @@ module.exports = function(loadThrift) {
             allowFilesystemAccess: allowFilesystemAccess,
             idls: idls
         }, function (err, thrift) {
+            assert.ifError(err);
             assert.ok(thrift.modules.typedef,
                 'modules includes typedef thrift instance');
             assert.end();
@@ -113,6 +118,7 @@ module.exports = function(loadThrift) {
             allowFilesystemAccess: allowFilesystemAccess,
             idls: idls
         }, function (err, thriftA) {
+            assert.ifError(err);
             var thriftB = thriftA.B;
 
             assert.equal(
@@ -233,4 +239,5 @@ module.exports = function(loadThrift) {
             assert.end();
         });
     });
-}
+
+});

--- a/test/index.js
+++ b/test/index.js
@@ -20,103 +20,41 @@
 
 'use strict';
 
-var Thrift = require('../thrift').Thrift;
-var fs = require('fs');
-var path = require('path');
-
-var testFiles = [
-    require('./binary'),
-    require('./boolean'),
-    require('./double'),
-    require('./i8'),
-    require('./i16'),
-    require('./i32'),
-    require('./i64'),
-    require('./map-entries'),
-    require('./thrift-idl'),
-    require('./map-object'),
-    require('./string'),
-    require('./tlist'),
-    require('./tmap'),
-    require('./tstruct'),
-    require('./void'),
-    require('./skip'),
-    require('./struct'),
-    require('./struct-skip'),
-    require('./recursion'),
-    require('./exception'),
-    require('./union'),
-    require('./service'),
-    require('./thrift'),
-    require('./list'),
-    require('./set'),
-    require('./map'),
-    require('./typedef'),
-    require('./const'),
-    require('./default'),
-    require('./enum'),
-    require('./unrecognized-exception'),
-    require('./include.js'),
-    require('./type-mismatch'),
-    require('./lcp'),
-    require('./idls'),
-    require('./asts'),
-    require('./message'),
-    require('./async-each')
-]
-
-function asyncReadFile(filename, cb) {
-    var error;
-    var source;
-    if (process.browser) {
-        source = global.idls[filename];
-        if (!source) {
-            error = Error(filename + ': missing file');
-        }
-    } else {
-        try {
-            source = fs.readFileSync(path.resolve(filename), 'ascii');
-        } catch (err) {
-            error = err;
-        }
-    }
-    setTimeout(function () { cb(error, source); }, 10);
-}
-
-function readFileNotExpected(_, cb) {
-    cb(Error('Thrift must be constructed with options.fs.readFile'))
-}
-
-function loadThriftAsync(options, cb) {
-    if (options && typeof options === 'object')
-    {
-        var readFile = readFileNotExpected;
-        if (options.allowFilesystemAccess || options.fs) {
-            readFile = asyncReadFile;
-        }
-        options.fs = {readFile: readFile};
-        delete options.allowFilesystemAccess;
-    }
-    Thrift.load(options, cb);
-}
-
-function loadThriftSync(options, cb) {
-    var thrift;
-    var error;
-    try {
-        thrift = new Thrift(options);
-    } catch (err) {
-        error = err;
-    }
-    cb(error, thrift);
-}
-
-// Run two passes: one with synchronous source loading, one with asynchronous loading.
-
-testFiles.forEach(function (testFile) {
-    testFile(loadThriftSync);
-});
-
-testFiles.forEach(function (testFile) {
-    testFile(loadThriftAsync);
-});
+require('./async-each');
+require('./binary');
+require('./boolean');
+require('./double');
+require('./i8');
+require('./i16');
+require('./i32');
+require('./i64');
+require('./map-entries');
+require('./thrift-idl');
+require('./map-object');
+require('./string');
+require('./tlist');
+require('./tmap');
+require('./tstruct');
+require('./void');
+require('./skip');
+require('./struct');
+require('./struct-skip');
+require('./recursion');
+require('./exception');
+require('./union');
+require('./service');
+require('./thrift');
+require('./list');
+require('./set');
+require('./map');
+require('./typedef');
+require('./const');
+require('./default');
+require('./enum');
+require('./unrecognized-exception');
+require('./include.js');
+require('./type-mismatch');
+require('./lcp');
+require('./idls');
+require('./asts');
+require('./message');

--- a/test/lcp.js
+++ b/test/lcp.js
@@ -20,71 +20,68 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var lcp = require('../lib/lcp');
 
-    var test = require('tape');
-    var lcp = require('../lib/lcp');
+var prefixTests = [
+    {strings: [], length: Infinity},
+    {strings: [''], length: 0},
+    {strings: ['a', 'b'], length: 0},
+    {strings: ['ac', 'ab'], length: 1},
+    {strings: ['aac', 'aab'], length: 2},
+    {strings: ['aac', 'aab', 'aab'], length: 2},
+    {strings: ['aaaa', 'aaa', 'aa', 'a'], length: 1}
+];
 
-    var prefixTests = [
-        {strings: [], length: Infinity},
-        {strings: [''], length: 0},
-        {strings: ['a', 'b'], length: 0},
-        {strings: ['ac', 'ab'], length: 1},
-        {strings: ['aac', 'aab'], length: 2},
-        {strings: ['aac', 'aab', 'aab'], length: 2},
-        {strings: ['aaaa', 'aaa', 'aa', 'a'], length: 1}
-    ];
+test('lengths of common prefixes', function t(assert) {
+    for (var i = 0; i < prefixTests.length; i++) {
+        var prefixTest = prefixTests[i];
+        assert.equal(
+            lcp.lengthOfCommonPrefix(prefixTest.strings),
+            prefixTest.length,
+            'length of common prefix among ' +
+            JSON.stringify(prefixTest.strings)
+        );
+    }
+    assert.end();
+});
 
-    test('lengths of common prefixes', function t(assert) {
-        for (var i = 0; i < prefixTests.length; i++) {
-            var prefixTest = prefixTests[i];
-            assert.equal(
-                lcp.lengthOfCommonPrefix(prefixTest.strings),
-                prefixTest.length,
-                'length of common prefix among ' +
-                JSON.stringify(prefixTest.strings)
-            );
-        }
-        assert.end();
-    });
+var pathTests = [
+    {paths: [
+        '/home/luser/app/idl/alice/alice.thrift',
+        '/home/luser/app/idl/bob/bob.thrift',
+        '/home/luser/app/idl/charlie/charlie.thrift',
+        '/home/luser/app/idl/common.thrift'
+    ], path: '/home/luser/app/idl/'},
+    {paths: [
+        '/home/luser/app/idl/alice/alice.thrift',
+        '/home/luser/app/idl/alice.thrift'
+    ], path: '/home/luser/app/idl/'},
+    {paths: [
+        '/home/luser/app/idl/alice',
+        '/home/luser/app/idl/bob'
+    ], path: '/home/luser/app/idl/'},
+    {paths: [
+        '/home/luser/app/idl/',
+        '/home/luser/app/idl/'
+    ], path: '/home/luser/app/idl/'},
+    {paths: [
+        'service.thrift'
+    ], path: ''},
+    {paths: [
+        '/home/luser/app/idl/service.thrift'
+    ], path: '/home/luser/app/idl/'}
+];
 
-    var pathTests = [
-        {paths: [
-            '/home/luser/app/idl/alice/alice.thrift',
-            '/home/luser/app/idl/bob/bob.thrift',
-            '/home/luser/app/idl/charlie/charlie.thrift',
-            '/home/luser/app/idl/common.thrift'
-        ], path: '/home/luser/app/idl/'},
-        {paths: [
-            '/home/luser/app/idl/alice/alice.thrift',
-            '/home/luser/app/idl/alice.thrift'
-        ], path: '/home/luser/app/idl/'},
-        {paths: [
-            '/home/luser/app/idl/alice',
-            '/home/luser/app/idl/bob'
-        ], path: '/home/luser/app/idl/'},
-        {paths: [
-            '/home/luser/app/idl/',
-            '/home/luser/app/idl/'
-        ], path: '/home/luser/app/idl/'},
-        {paths: [
-            'service.thrift'
-        ], path: ''},
-        {paths: [
-            '/home/luser/app/idl/service.thrift'
-        ], path: '/home/luser/app/idl/'}
-    ];
-
-    test('common parent directory', function t(assert) {
-        for (var i = 0; i < pathTests.length; i++) {
-            var pathTest = pathTests[i];
-            assert.equal(
-                lcp.longestCommonPath(pathTest.paths),
-                pathTest.path,
-                'length of common parent directory among ' +
-                JSON.stringify(pathTest.paths)
-            );
-        }
-        assert.end();
-    });
-}
+test('common parent directory', function t(assert) {
+    for (var i = 0; i < pathTests.length; i++) {
+        var pathTest = pathTests[i];
+        assert.equal(
+            lcp.longestCommonPath(pathTest.paths),
+            pathTest.path,
+            'length of common parent directory among ' +
+            JSON.stringify(pathTest.paths)
+        );
+    }
+    assert.end();
+});

--- a/test/list.js
+++ b/test/list.js
@@ -20,16 +20,20 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var path = require('path');
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var path = require('path');
-    var fs = require('fs');
-    var path = require('path');
+withLoader(function (loadThrift, test) {
 
     var source = fs.readFileSync(path.join(__dirname, 'list.thrift'), 'ascii');
     loadThrift({source: source}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
 
         var byteList = thrift.models.ListOfI8;
         var stringList = thrift.models.ListOfString;
@@ -127,4 +131,5 @@ module.exports = function(loadThrift) {
 
         ]));
     });
-}
+
+});

--- a/test/loader.js
+++ b/test/loader.js
@@ -1,0 +1,90 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var fs = require('fs');
+var path = require('path');
+var test = require('tape');
+var Thrift = require('../thrift').Thrift;
+
+function asyncReadFile(filename, cb) {
+    var error;
+    var source;
+    if (process.browser) {
+        source = global.idls[filename];
+        if (!source) {
+            error = Error(filename + ': missing file');
+        }
+    } else {
+        try {
+            source = fs.readFileSync(path.resolve(filename), 'ascii');
+        } catch (err) {
+            error = err;
+        }
+    }
+    setTimeout(function () {
+        cb(error, source);
+    }, 0);
+}
+
+function readFileNotExpected(_, cb) {
+    cb(Error('Thrift must be constructed with options.fs.readFile'))
+}
+
+function loadThriftAsync(options, cb) {
+    if (options && typeof options === 'object') {
+        var readFile = readFileNotExpected;
+        if (options.allowFilesystemAccess || options.fs) {
+            readFile = asyncReadFile;
+        }
+        options.fs = {readFile: readFile};
+        delete options.allowFilesystemAccess;
+    }
+    try {
+        Thrift.load(options, cb);
+    } catch (err) {
+        cb(err);
+    }
+}
+
+function loadThriftSync(options, cb) {
+    var thrift;
+    var error;
+    try {
+        thrift = new Thrift(options);
+    } catch (err) {
+        error = err;
+    }
+    cb(error, thrift);
+}
+
+function testSync(name, testCase) {
+    test(name + ' sync', testCase);
+}
+
+function testAsync(name, testCase) {
+    test(name + ' async', testCase);
+}
+
+function withLoader(f) {
+    f(loadThriftSync, testSync);
+    f(loadThriftAsync, testAsync);
+}
+
+module.exports = withLoader;

--- a/test/loader.js
+++ b/test/loader.js
@@ -18,6 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// The loader test module is a utility for validating both the synchronous
+// Thrift constructor and the asynchronous Thrift.load constructor.
+// The exported withLoader function calls back twice, once with synchronous
+// loadThrift and testThrift functions and again with asynchronous versions.
+// This allows some tests, particularly those that exercise Thrift IDL files
+// that have "include" directives, to exercise both the synchronous and
+// asynchronous code paths.
+
 var fs = require('fs');
 var path = require('path');
 var test = require('tape');

--- a/test/map-entries.js
+++ b/test/map-entries.js
@@ -20,161 +20,158 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var bufrw = require('bufrw');
+var testRW = require('bufrw/test_rw');
 
-    var test = require('tape');
-    var bufrw = require('bufrw');
-    var testRW = require('bufrw/test_rw');
+var thriftrw = require('../index');
+var MapEntriesRW = thriftrw.MapEntriesRW;
 
-    var thriftrw = require('../index');
-    var MapEntriesRW = thriftrw.MapEntriesRW;
+var strType = {
+    name: 'string',
+    typeid: 1,
+    rw: bufrw.str1
+};
+var i16Type = {
+    name: 'i16',
+    typeid: 2,
+    rw: bufrw.Int16BE
+};
 
-    var strType = {
-        name: 'string',
-        typeid: 1,
-        rw: bufrw.str1
-    };
-    var i16Type = {
-        name: 'i16',
-        typeid: 2,
-        rw: bufrw.Int16BE
-    };
+var strI16MapRW = new MapEntriesRW(strType, i16Type);
+test('MapEntriesRW: strI16MapRW', testRW.cases(strI16MapRW, [
+    [[], [
+        0x01,                  // key_type:1 -- 99
+        0x02,                  // val_type:1 -- 98
+        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+    ]],
 
-    var strI16MapRW = new MapEntriesRW(strType, i16Type);
-    test('MapEntriesRW: strI16MapRW', testRW.cases(strI16MapRW, [
-        [[], [
-            0x01,                  // key_type:1 -- 99
-            0x02,                  // val_type:1 -- 98
-            0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-        ]],
+    [[
+        ['abc', 1],
+        ['def', 2],
+        ['ghi', 3]
+    ], [
+        0x01,                   // key_type:1 -- 99
+        0x02,                   // val_type:1 -- 98
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x00, 0x01,             // Int16BE    -- 1
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x00, 0x02,             // Int16BE    -- 2
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x00, 0x03              // Int16BE    -- 3
+    ]],
 
-        [[
-            ['abc', 1],
-            ['def', 2],
-            ['ghi', 3]
-        ], [
-            0x01,                   // key_type:1 -- 99
-            0x02,                   // val_type:1 -- 98
-            0x00, 0x00, 0x00, 0x03, // length:4   -- 3
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x61, 0x62, 0x63,       // chars      -- "abc"
-            0x00, 0x01,             // Int16BE    -- 1
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x64, 0x65, 0x66,       // chars      -- "def"
-            0x00, 0x02,             // Int16BE    -- 2
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x67, 0x68, 0x69,       // chars      -- "ghi"
-            0x00, 0x03              // Int16BE    -- 3
-        ]],
-
-        {
-            readTest: {
-                bytes: [
-                    0x09,                  // key_type:1 -- 99
-                    0x02,                  // val_type:1 -- 98
-                    0x00, 0x00, 0x00, 0x00 // length:4   -- 3
-                ],
-                error: {
-                    type: 'thrift-map-key-typeid-mismatch',
-                    name: 'ThriftMapKeyTypeidMismatchError',
-                    message: 'encoded map key typeid 9 doesn\'t match expected ' +
-                             'type "string" (id: 1)'
-                }
-            }
-        },
-
-        {
-            readTest: {
-                bytes: [
-                    0x01,                  // key_type:1 -- 99
-                    0x09,                  // val_type:1 -- 98
-                    0x00, 0x00, 0x00, 0x00 // length:4   -- 3
-                ],
-                error: {
-                    type: 'thrift-map-val-typeid-mismatch',
-                    name: 'ThriftMapValTypeidMismatchError',
-                    message: 'encoded map value typeid 9 doesn\'t match expected ' +
-                             'type "i16" (id: 2)'
-                }
+    {
+        readTest: {
+            bytes: [
+                0x09,                  // key_type:1 -- 99
+                0x02,                  // val_type:1 -- 98
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 3
+            ],
+            error: {
+                type: 'thrift-map-key-typeid-mismatch',
+                name: 'ThriftMapKeyTypeidMismatchError',
+                message: 'encoded map key typeid 9 doesn\'t match expected ' +
+                         'type "string" (id: 1)'
             }
         }
-    ]));
+    },
 
-    var i16StrMapRW = new MapEntriesRW(i16Type, strType);
-    test('MapEntriesRW: i16StrMapRW', testRW.cases(i16StrMapRW, [
-        [[
-            [1, 'abc'],
-            [2, 'def'],
-            [3, 'ghi']
-        ], [
-            0x02,                   // key_type:1 -- 98
-            0x01,                   // val_type:1 -- 99
-            0x00, 0x00, 0x00, 0x03, // length:4   -- 3
-                                    //            --
-            0x00, 0x01,             // Int16BE    -- 1
-            0x03,                   // str_len:4  -- 3
-            0x61, 0x62, 0x63,       // chars      -- "abc"
-                                    //            --
-            0x00, 0x02,             // Int16BE    -- 2
-            0x03,                   // str_len:4  -- 3
-            0x64, 0x65, 0x66,       // chars      -- "def"
-                                    //            --
-            0x00, 0x03,             // Int16BE    -- 3
-            0x03,                   // str_len:4  -- 3
-            0x67, 0x68, 0x69        // chars      -- "ghi"
-        ]]
-    ]));
+    {
+        readTest: {
+            bytes: [
+                0x01,                  // key_type:1 -- 99
+                0x09,                  // val_type:1 -- 98
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 3
+            ],
+            error: {
+                type: 'thrift-map-val-typeid-mismatch',
+                name: 'ThriftMapValTypeidMismatchError',
+                message: 'encoded map value typeid 9 doesn\'t match expected ' +
+                         'type "i16" (id: 2)'
+            }
+        }
+    }
+]));
 
-    var i16I16MapRW = new MapEntriesRW(i16Type, i16Type);
-    test('MapEntriesRW: i16I16MapRW', testRW.cases(i16I16MapRW, [
-        [[
-            [1, 4],
-            [2, 5],
-            [3, 6]
-        ], [
-            0x02,                   // key_type:1 -- 98
-            0x02,                   // val_type:1 -- 99
-            0x00, 0x00, 0x00, 0x03, // length:4   -- 3
-                                    //            --
-            0x00, 0x01,             // Int16BE    -- 1
-            0x00, 0x04,             // Int16BE    -- 4
-                                    //            --
-            0x00, 0x02,             // Int16BE    -- 2
-            0x00, 0x05,             // Int16BE    -- 5
-                                    //            --
-            0x00, 0x03,             // Int16BE    -- 3
-            0x00, 0x06              // Int16BE    -- 3
-        ]]
-    ]));
+var i16StrMapRW = new MapEntriesRW(i16Type, strType);
+test('MapEntriesRW: i16StrMapRW', testRW.cases(i16StrMapRW, [
+    [[
+        [1, 'abc'],
+        [2, 'def'],
+        [3, 'ghi']
+    ], [
+        0x02,                   // key_type:1 -- 98
+        0x01,                   // val_type:1 -- 99
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x00, 0x01,             // Int16BE    -- 1
+        0x03,                   // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+                                //            --
+        0x00, 0x02,             // Int16BE    -- 2
+        0x03,                   // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+                                //            --
+        0x00, 0x03,             // Int16BE    -- 3
+        0x03,                   // str_len:4  -- 3
+        0x67, 0x68, 0x69        // chars      -- "ghi"
+    ]]
+]));
 
-    var strStrMapRW = new MapEntriesRW(strType, strType);
-    test('MapEntriesRW: strStrMapRW', testRW.cases(strStrMapRW, [
-        [[
-            ['abc', 'ABC'],
-            ['def', 'DEF'],
-            ['ghi', 'GHI']
-        ], [
-            0x01,                   // key_type:1 -- 99
-            0x01,                   // val_type:1 -- 98
-            0x00, 0x00, 0x00, 0x03, // length:4   -- 3
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x61, 0x62, 0x63,       // chars      -- "abc"
-            0x03,                   // str_len:4  -- 3
-            0x41, 0x42, 0x43,       // chars      -- "ABC"
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x64, 0x65, 0x66,       // chars      -- "def"
-            0x03,                   // str_len:4  -- 3
-            0x44, 0x45, 0x46,       // chars      -- "DEF"
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x67, 0x68, 0x69,       // chars      -- "ghi"
-            0x03,                   // str_len:4  -- 3
-            0x47, 0x48, 0x49        // chars      -- "GHI"
-        ]]
-    ]));
-}
+var i16I16MapRW = new MapEntriesRW(i16Type, i16Type);
+test('MapEntriesRW: i16I16MapRW', testRW.cases(i16I16MapRW, [
+    [[
+        [1, 4],
+        [2, 5],
+        [3, 6]
+    ], [
+        0x02,                   // key_type:1 -- 98
+        0x02,                   // val_type:1 -- 99
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x00, 0x01,             // Int16BE    -- 1
+        0x00, 0x04,             // Int16BE    -- 4
+                                //            --
+        0x00, 0x02,             // Int16BE    -- 2
+        0x00, 0x05,             // Int16BE    -- 5
+                                //            --
+        0x00, 0x03,             // Int16BE    -- 3
+        0x00, 0x06              // Int16BE    -- 3
+    ]]
+]));
+
+var strStrMapRW = new MapEntriesRW(strType, strType);
+test('MapEntriesRW: strStrMapRW', testRW.cases(strStrMapRW, [
+    [[
+        ['abc', 'ABC'],
+        ['def', 'DEF'],
+        ['ghi', 'GHI']
+    ], [
+        0x01,                   // key_type:1 -- 99
+        0x01,                   // val_type:1 -- 98
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x03,                   // str_len:4  -- 3
+        0x41, 0x42, 0x43,       // chars      -- "ABC"
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x03,                   // str_len:4  -- 3
+        0x44, 0x45, 0x46,       // chars      -- "DEF"
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x03,                   // str_len:4  -- 3
+        0x47, 0x48, 0x49        // chars      -- "GHI"
+    ]]
+]));

--- a/test/map-object.js
+++ b/test/map-object.js
@@ -20,114 +20,111 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var bufrw = require('bufrw');
+var testRW = require('bufrw/test_rw');
 
-    var test = require('tape');
-    var bufrw = require('bufrw');
-    var testRW = require('bufrw/test_rw');
+var thriftrw = require('../index');
+var MapObjectRW = thriftrw.MapObjectRW;
 
-    var thriftrw = require('../index');
-    var MapObjectRW = thriftrw.MapObjectRW;
+var strType = {
+    name: 'string',
+    typeid: 1,
+    rw: bufrw.str1
+};
+var i16Type = {
+    name: 'i16',
+    typeid: 2,
+    rw: bufrw.Int16BE
+};
 
-    var strType = {
-        name: 'string',
-        typeid: 1,
-        rw: bufrw.str1
-    };
-    var i16Type = {
-        name: 'i16',
-        typeid: 2,
-        rw: bufrw.Int16BE
-    };
+var strI16MapRW = new MapObjectRW(strType, i16Type);
+test('MapObjectRW: strI16MapRW', testRW.cases(strI16MapRW, [
+    [{}, [
+        0x01,                  // key_type:1 -- 99
+        0x02,                  // val_type:1 -- 98
+        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+    ]],
 
-    var strI16MapRW = new MapObjectRW(strType, i16Type);
-    test('MapObjectRW: strI16MapRW', testRW.cases(strI16MapRW, [
-        [{}, [
-            0x01,                  // key_type:1 -- 99
-            0x02,                  // val_type:1 -- 98
-            0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-        ]],
+    [{
+        'abc': 1,
+        'def': 2,
+        'ghi': 3
+    }, [
+        0x01,                   // key_type:1 -- 99
+        0x02,                   // val_type:1 -- 98
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x00, 0x01,             // Int16BE    -- 1
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x00, 0x02,             // Int16BE    -- 2
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x00, 0x03              // Int16BE    -- 3
+    ]],
 
-        [{
-            'abc': 1,
-            'def': 2,
-            'ghi': 3
-        }, [
-            0x01,                   // key_type:1 -- 99
-            0x02,                   // val_type:1 -- 98
-            0x00, 0x00, 0x00, 0x03, // length:4   -- 3
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x61, 0x62, 0x63,       // chars      -- "abc"
-            0x00, 0x01,             // Int16BE    -- 1
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x64, 0x65, 0x66,       // chars      -- "def"
-            0x00, 0x02,             // Int16BE    -- 2
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x67, 0x68, 0x69,       // chars      -- "ghi"
-            0x00, 0x03              // Int16BE    -- 3
-        ]],
-
-        {
-            readTest: {
-                bytes: [
-                    0x09,                  // key_type:1 -- 99
-                    0x02,                  // val_type:1 -- 98
-                    0x00, 0x00, 0x00, 0x00 // length:4   -- 3
-                ],
-                error: {
-                    type: 'thrift-map-key-typeid-mismatch',
-                    name: 'ThriftMapKeyTypeidMismatchError',
-                    message: 'encoded map key typeid 9 doesn\'t match expected ' +
-                             'type "string" (id: 1)'
-                }
-            }
-        },
-
-        {
-            readTest: {
-                bytes: [
-                    0x01,                  // key_type:1 -- 99
-                    0x09,                  // val_type:1 -- 98
-                    0x00, 0x00, 0x00, 0x00 // length:4   -- 3
-                ],
-                error: {
-                    type: 'thrift-map-val-typeid-mismatch',
-                    name: 'ThriftMapValTypeidMismatchError',
-                    message: 'encoded map value typeid 9 doesn\'t match expected ' +
-                             'type "i16" (id: 2)'
-                }
+    {
+        readTest: {
+            bytes: [
+                0x09,                  // key_type:1 -- 99
+                0x02,                  // val_type:1 -- 98
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 3
+            ],
+            error: {
+                type: 'thrift-map-key-typeid-mismatch',
+                name: 'ThriftMapKeyTypeidMismatchError',
+                message: 'encoded map key typeid 9 doesn\'t match expected ' +
+                         'type "string" (id: 1)'
             }
         }
-    ]));
+    },
 
-    var strStrMapRW = new MapObjectRW(strType, strType);
-    test('MapObjectRW: strStrMapRW', testRW.cases(strStrMapRW, [
-        [{
-            'abc': 'ABC',
-            'def': 'DEF',
-            'ghi': 'GHI'
-        }, [
-            0x01,                   // key_type:1 -- 99
-            0x01,                   // val_type:1 -- 98
-            0x00, 0x00, 0x00, 0x03, // length:4   -- 3
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x61, 0x62, 0x63,       // chars      -- "abc"
-            0x03,                   // str_len:4  -- 3
-            0x41, 0x42, 0x43,       // chars      -- "ABC"
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x64, 0x65, 0x66,       // chars      -- "def"
-            0x03,                   // str_len:4  -- 3
-            0x44, 0x45, 0x46,       // chars      -- "DEF"
-                                    //            --
-            0x03,                   // str_len:4  -- 3
-            0x67, 0x68, 0x69,       // chars      -- "ghi"
-            0x03,                   // str_len:4  -- 3
-            0x47, 0x48, 0x49        // chars      -- "GHI"
-        ]]
-    ]));
-}
+    {
+        readTest: {
+            bytes: [
+                0x01,                  // key_type:1 -- 99
+                0x09,                  // val_type:1 -- 98
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 3
+            ],
+            error: {
+                type: 'thrift-map-val-typeid-mismatch',
+                name: 'ThriftMapValTypeidMismatchError',
+                message: 'encoded map value typeid 9 doesn\'t match expected ' +
+                         'type "i16" (id: 2)'
+            }
+        }
+    }
+]));
+
+var strStrMapRW = new MapObjectRW(strType, strType);
+test('MapObjectRW: strStrMapRW', testRW.cases(strStrMapRW, [
+    [{
+        'abc': 'ABC',
+        'def': 'DEF',
+        'ghi': 'GHI'
+    }, [
+        0x01,                   // key_type:1 -- 99
+        0x01,                   // val_type:1 -- 98
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x03,                   // str_len:4  -- 3
+        0x41, 0x42, 0x43,       // chars      -- "ABC"
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x03,                   // str_len:4  -- 3
+        0x44, 0x45, 0x46,       // chars      -- "DEF"
+                                //            --
+        0x03,                   // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x03,                   // str_len:4  -- 3
+        0x47, 0x48, 0x49        // chars      -- "GHI"
+    ]]
+]));

--- a/test/map.js
+++ b/test/map.js
@@ -20,16 +20,20 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var path = require('path');
+var fs = require('fs');
+var ThriftMap = require('../map').ThriftMap;
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var path = require('path');
-    var fs = require('fs');
-    var ThriftMap = require('../map').ThriftMap;
+withLoader(function (loadThrift, test) {
 
     var source = fs.readFileSync(path.join(__dirname, 'map.thrift'), 'ascii');
     var thrift = loadThrift({source: source}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
 
         var strI16Map = thrift.models.Graph.fieldsByName.stringsToI16s.valueType;
         var strI16MapEntries = thrift.models.Graph.fieldsByName.stringsToI16Entries.valueType;
@@ -204,4 +208,5 @@ module.exports = function(loadThrift) {
             });
         });
     });
-}
+
+});

--- a/test/map.js
+++ b/test/map.js
@@ -25,188 +25,180 @@ var testRW = require('bufrw/test_rw');
 var path = require('path');
 var fs = require('fs');
 var ThriftMap = require('../map').ThriftMap;
-var withLoader = require('./loader');
+var Thrift = require('../thrift').Thrift;
 
-withLoader(function (loadThrift, test) {
+var source = fs.readFileSync(path.join(__dirname, 'map.thrift'), 'ascii');
+var thrift = new Thrift({source: source});
 
-    var source = fs.readFileSync(path.join(__dirname, 'map.thrift'), 'ascii');
-    var thrift = loadThrift({source: source}, function (err, thrift) {
-        if (err) {
-            throw err;
+var strI16Map = thrift.models.Graph.fieldsByName.stringsToI16s.valueType;
+var strI16MapEntries = thrift.models.Graph.fieldsByName.stringsToI16Entries.valueType;
+var i16I16Map = thrift.models.Graph.fieldsByName.i16sToI16s;
+
+test('ThriftMap: strI16MapRW', testRW.cases(strI16Map.rw, [
+    [{}, [
+        0x0b,                  // key_type:1 -- 11, string
+        0x06,                  // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+    ]],
+
+    [{
+        'abc': 1,
+        'def': 2,
+        'ghi': 3
+    }, [
+        0x0b,                   // key_type:1 -- 11, string
+        0x06,                   // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x00, 0x01,             // Int16BE    -- 1
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x00, 0x02,             // Int16BE    -- 2
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x00, 0x03              // Int16BE    -- 3
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x09,                  // key_type:1 -- 9
+                0x02,                  // val_type:1 -- 2
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-key-typeid-mismatch',
+                name: 'ThriftMapKeyTypeidMismatchError',
+                message: 'encoded map key typeid 9 doesn\'t match expected ' +
+                         'type "string" (id: 11)'
+            }
         }
+    },
 
-        var strI16Map = thrift.models.Graph.fieldsByName.stringsToI16s.valueType;
-        var strI16MapEntries = thrift.models.Graph.fieldsByName.stringsToI16Entries.valueType;
-        var i16I16Map = thrift.models.Graph.fieldsByName.i16sToI16s;
-
-        test('ThriftMap: strI16MapRW', testRW.cases(strI16Map.rw, [
-            [{}, [
-                0x0b,                  // key_type:1 -- 11, string
-                0x06,                  // val_type:1 -- 6, i16
+    {
+        readTest: {
+            bytes: [
+                0x0b,                  // key_type:1 -- 11
+                0x09,                  // val_type:1 -- 9
                 0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-            ]],
-
-            [{
-                'abc': 1,
-                'def': 2,
-                'ghi': 3
-            }, [
-                0x0b,                   // key_type:1 -- 11, string
-                0x06,                   // val_type:1 -- 6, i16
-                0x00, 0x00, 0x00, 0x03, // length:4   -- 3
-                                        //            --
-                0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
-                0x61, 0x62, 0x63,       // chars      -- "abc"
-                0x00, 0x01,             // Int16BE    -- 1
-                                        //            --
-                0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
-                0x64, 0x65, 0x66,       // chars      -- "def"
-                0x00, 0x02,             // Int16BE    -- 2
-                                        //            --
-                0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
-                0x67, 0x68, 0x69,       // chars      -- "ghi"
-                0x00, 0x03              // Int16BE    -- 3
-            ]],
-
-            {
-                readTest: {
-                    bytes: [
-                        0x09,                  // key_type:1 -- 9
-                        0x02,                  // val_type:1 -- 2
-                        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-                    ],
-                    error: {
-                        type: 'thrift-map-key-typeid-mismatch',
-                        name: 'ThriftMapKeyTypeidMismatchError',
-                        message: 'encoded map key typeid 9 doesn\'t match expected ' +
-                                 'type "string" (id: 11)'
-                    }
-                }
-            },
-
-            {
-                readTest: {
-                    bytes: [
-                        0x0b,                  // key_type:1 -- 11
-                        0x09,                  // val_type:1 -- 9
-                        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-                    ],
-                    error: {
-                        type: 'thrift-map-val-typeid-mismatch',
-                        name: 'ThriftMapValTypeidMismatchError',
-                        message: 'encoded map value typeid 9 doesn\'t match expected ' +
-                                 'type "i16" (id: 6)'
-                    }
-                }
+            ],
+            error: {
+                type: 'thrift-map-val-typeid-mismatch',
+                name: 'ThriftMapValTypeidMismatchError',
+                message: 'encoded map value typeid 9 doesn\'t match expected ' +
+                         'type "i16" (id: 6)'
             }
+        }
+    }
 
-        ]));
+]));
 
-        test('ThriftMap: strI16MapRW', testRW.cases(strI16MapEntries.rw, [
-            [[], [
-                0x0b,                  // key_type:1 -- 11, string
-                0x06,                  // val_type:1 -- 6, i16
+test('ThriftMap: strI16MapRW', testRW.cases(strI16MapEntries.rw, [
+    [[], [
+        0x0b,                  // key_type:1 -- 11, string
+        0x06,                  // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+    ]],
+
+    [[
+        ['abc', 1],
+        ['def', 2],
+        ['ghi', 3]
+    ], [
+        0x0b,                   // key_type:1 -- 11, string
+        0x06,                   // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x00, 0x01,             // Int16BE    -- 1
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x00, 0x02,             // Int16BE    -- 2
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x00, 0x03              // Int16BE    -- 3
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x09,                  // key_type:1 -- 9
+                0x02,                  // val_type:1 -- 2
                 0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-            ]],
-
-            [[
-                ['abc', 1],
-                ['def', 2],
-                ['ghi', 3]
-            ], [
-                0x0b,                   // key_type:1 -- 11, string
-                0x06,                   // val_type:1 -- 6, i16
-                0x00, 0x00, 0x00, 0x03, // length:4   -- 3
-                                        //            --
-                0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
-                0x61, 0x62, 0x63,       // chars      -- "abc"
-                0x00, 0x01,             // Int16BE    -- 1
-                                        //            --
-                0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
-                0x64, 0x65, 0x66,       // chars      -- "def"
-                0x00, 0x02,             // Int16BE    -- 2
-                                        //            --
-                0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
-                0x67, 0x68, 0x69,       // chars      -- "ghi"
-                0x00, 0x03              // Int16BE    -- 3
-            ]],
-
-            {
-                readTest: {
-                    bytes: [
-                        0x09,                  // key_type:1 -- 9
-                        0x02,                  // val_type:1 -- 2
-                        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-                    ],
-                    error: {
-                        type: 'thrift-map-key-typeid-mismatch',
-                        name: 'ThriftMapKeyTypeidMismatchError',
-                        message: 'encoded map key typeid 9 doesn\'t match expected ' +
-                                 'type "string" (id: 11)'
-                    }
-                }
-            },
-
-            {
-                readTest: {
-                    bytes: [
-                        0x0b,                  // key_type:1 -- 11
-                        0x09,                  // val_type:1 -- 9
-                        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-                    ],
-                    error: {
-                        type: 'thrift-map-val-typeid-mismatch',
-                        name: 'ThriftMapValTypeidMismatchError',
-                        message: 'encoded map value typeid 9 doesn\'t match expected ' +
-                                 'type "i16" (id: 6)'
-                    }
-                }
+            ],
+            error: {
+                type: 'thrift-map-key-typeid-mismatch',
+                name: 'ThriftMapKeyTypeidMismatchError',
+                message: 'encoded map key typeid 9 doesn\'t match expected ' +
+                         'type "string" (id: 11)'
             }
+        }
+    },
 
-        ]));
+    {
+        readTest: {
+            bytes: [
+                0x0b,                  // key_type:1 -- 11
+                0x09,                  // val_type:1 -- 9
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-val-typeid-mismatch',
+                name: 'ThriftMapValTypeidMismatchError',
+                message: 'encoded map value typeid 9 doesn\'t match expected ' +
+                         'type "i16" (id: 6)'
+            }
+        }
+    }
 
-        test('map<i8, i8>', testRW.cases(thrift.models.MapI8I8.rw, [
-            [{2: 3}, [
-                0x03,                   // key_type:1 -- 3, i8
-                0x03,                   // val_type:1 -- 3, i8
-                0x00, 0x00, 0x00, 0x01, // length:4   -- 1
-                0x02,                   // [0] key -- 2
-                0x03                    // [1] value -- 3
-            ]]
-        ]));
+]));
 
-        test('map<i16, i16>', testRW.cases(thrift.models.MapI16I16.rw, [
-            [{2: 3}, [
-                0x06,                   // key_type:1 -- 6, i16
-                0x06,                   // val_type:1 -- 6, i16
-                0x00, 0x00, 0x00, 0x01, // length:4   -- 1
-                0x00, 0x02,             // [0] key -- 2
-                0x00, 0x03              // [1] value -- 3
-            ]]
-        ]));
+test('map<i8, i8>', testRW.cases(thrift.models.MapI8I8.rw, [
+    [{2: 3}, [
+        0x03,                   // key_type:1 -- 3, i8
+        0x03,                   // val_type:1 -- 3, i8
+        0x00, 0x00, 0x00, 0x01, // length:4   -- 1
+        0x02,                   // [0] key -- 2
+        0x03                    // [1] value -- 3
+    ]]
+]));
 
-        test('map<i32, i32>', testRW.cases(thrift.models.MapI32I32.rw, [
-            [{2: 3}, [
-                0x08,                   // key_type:1 -- 8, i32
-                0x08,                   // val_type:1 -- 8, i32
-                0x00, 0x00, 0x00, 0x01, // length:4   -- 1
-                0x00, 0x00, 0x00, 0x02, // [0] key -- 2
-                0x00, 0x00, 0x00, 0x03  // [1] value -- 3
-            ]]
-        ]));
+test('map<i16, i16>', testRW.cases(thrift.models.MapI16I16.rw, [
+    [{2: 3}, [
+        0x06,                   // key_type:1 -- 6, i16
+        0x06,                   // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x01, // length:4   -- 1
+        0x00, 0x02,             // [0] key -- 2
+        0x00, 0x03              // [1] value -- 3
+    ]]
+]));
 
-        test('invalid map type annotation', function t(assert) {
-            loadThrift({
+test('map<i32, i32>', testRW.cases(thrift.models.MapI32I32.rw, [
+    [{2: 3}, [
+        0x08,                   // key_type:1 -- 8, i32
+        0x08,                   // val_type:1 -- 8, i32
+        0x00, 0x00, 0x00, 0x01, // length:4   -- 1
+        0x00, 0x00, 0x00, 0x02, // [0] key -- 2
+        0x00, 0x00, 0x00, 0x03  // [1] value -- 3
+    ]]
+]));
+
+test('invalid map type annotation', function t(assert) {
+    assert.throws(
+        function throws() {
+            new Thrift({
                 source: 'struct Graph { 1: required map<byte, byte> (js.type = "bogus") edges }'
-            }, function (err, thrift) {
-                assert.throws(
-                    function throws() { throw err; },
-                     /unexpected map js.type annotation "bogus"/,
-                    'Thrift should not parse with invalid map type'
-                );
-                assert.end();
             });
-        });
-    });
-
+        },
+         /unexpected map js.type annotation "bogus"/,
+        'Thrift should not parse with invalid map type'
+    );
+    assert.end();
 });

--- a/test/message.js
+++ b/test/message.js
@@ -22,14 +22,19 @@
 /* eslint max-len:[0, 120] */
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var path = require('path');
+var fs = require('fs');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var path = require('path');
-    var fs = require('fs');
+withLoader(function (loadThrift, test) {
 
     var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
     loadThrift({source: source}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
+
         test('round-trip a non-strict message', function t(assert) {
             var message = new thrift.Service.foo.ArgumentsMessage({
                 id: 0,
@@ -389,4 +394,5 @@ module.exports = function(loadThrift) {
             assert.end();
         });
     });
-}
+
+});

--- a/test/message.js
+++ b/test/message.js
@@ -25,374 +25,367 @@
 var test = require('tape');
 var path = require('path');
 var fs = require('fs');
-var withLoader = require('./loader');
+var Thrift = require('../thrift').Thrift;
 
-withLoader(function (loadThrift, test) {
+var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
+var thrift = new Thrift({source: source});
 
-    var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
-    loadThrift({source: source}, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
+test('round-trip a non-strict message', function t(assert) {
 
-        test('round-trip a non-strict message', function t(assert) {
-            var message = new thrift.Service.foo.ArgumentsMessage({
-                id: 0,
-                body: new thrift.Service.foo.Arguments({
-                    bar: new thrift.Struct({
-                        number: 10
-                    })
-                })
-            });
-
-            var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
-            var buffer = new Buffer(result.length);
-
-            var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
-
-            var expectedBuffer = new Buffer([
-                0x00, 0x00, 0x00, 0x03, // name.length:4
-                0x66, 0x6f, 0x6f,       // name:name.length
-                0x01,                   // type:1 = CALL
-                0x00, 0x00, 0x00, 0x00, // id:4
-                                        // body
-                0x0c,                   // struct
-                0x00, 0x01,             // field 1
-                0x08,                   // i32
-                0x00, 0x01,             // field 1
-                0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-                0x00,                   // end of foo
-                0x00                    // end of result
-            ]);
-            assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
-
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-
-            assert.deepEqual(result.value, message, 'read correctly');
-
-            assert.end();
-        });
-
-        test('round-trip a non-strict message', function t(assert) {
-            var message = new thrift.Service.foo.ArgumentsMessage({
-                version: 1,
-                id: 0,
-                body: new thrift.Service.foo.Arguments({
-                    bar: new thrift.Struct({
-                        number: 10
-                    })
-                })
-            });
-
-            var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
-            var buffer = new Buffer(result.length);
-            var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
-
-            var expectedBuffer = new Buffer([
-                0x80,                   // strict
-                0x01,                   // version = 1
-                0x00,                   // shrug
-                0x01,                   // type = CALL
-                0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
-                0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
-                0x00, 0x00, 0x00, 0x00, // id:4 = 0
-                                        // body
-                0x0c,                   // struct
-                0x00, 0x01,             // field 1
-                0x08,                   // i32
-                0x00, 0x01,             // field 1
-                0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-                0x00,                   // end of foo
-                0x00                    // end of result
-            ]);
-            assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
-
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-
-            assert.deepEqual(result.value, message, 'read correctly');
-
-            assert.end();
-        });
-
-        test('round trip an exception (legacy)', function t(assert) {
-            // TODO exercise version=1
-            var message = new thrift.Service.foo.ResultMessage({
-                id: 2,
-                type: 'EXCEPTION',
-                body: new thrift.exception.Constructor({
-                    message: 'Unknown method',
-                    type: 'UNKNOWN_METHOD'
-                })
-            });
-
-            var expectedBuffer = new Buffer([
-                0x00, 0x00, 0x00, 0x03, // name.length:4
-                0x66, 0x6f, 0x6f,       // name:name.length -- "foo"
-                0x03,                   // type:3 = EXCEPTION
-                0x00, 0x00, 0x00, 0x02, // id:4 -- 2
-                                        // exception
-                0x0b,                   // typeid:1 -- 11 -- STRING
-                0x00, 0x01,             // fieldid:2 -- 1 -- message
-                0x00, 0x00, 0x00, 0x0e, // length
-                0x55, 0x6e, 0x6b, 0x6e,
-                0x6f, 0x77, 0x6e, 0x20,
-                0x6d, 0x65, 0x74, 0x68,
-                0x6f, 0x64,
-                0x08,                   // typeid:1 -- 8 -- i32
-                0x00, 0x02,             // fieldid:2 -- 2 -- type
-                0x00, 0x00, 0x00, 0x01, // type:4 -- 1 -- UNKNOWN_METHOD
-                0x00                    // end of struct
-            ]);
-
-            var result = thrift.Service.foo.resultMessageRW.byteLength(message);
-            assert.equal(result.length, expectedBuffer.length, 'measured correctly');
-
-            var buffer = new Buffer(result.length);
-            buffer.fill(0xCC);
-
-            var result = thrift.Service.foo.resultMessageRW.writeInto(message, buffer, 0);
-            if (result.err) return assert.end(result.err);
-
-            assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
-
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-
-            assert.deepEqual(result.err, message.body, 'produced proper error');
-            assert.deepEqual(result.value, message, 'read correctly');
-
-            assert.end();
-        });
-
-        test('read unexpected version error', function t(assert) {
-            var buffer = new Buffer([
-                0x80,                   // strict
-                0x02,                   // version = 2 XXX BUT WHAT IS GOING ON WITH VERSION 2!?
-                0x00,                   // shrug
-                0x01,                   // type = CALL
-                0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
-                0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
-                0x00, 0x00, 0x00, 0x00, // id:4 = 0
-                                        // body
-                0x0c,                   // struct
-                0x00, 0x01,             // field 1
-                0x08,                   // i32
-                0x00, 0x01,             // field 1
-                0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-                0x00,                   // end of foo
-                0x00                    // end of result
-            ]);
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-            assert.equal(result.err.message, 'unrecognized Thrift message envelope version: 2',
-                'expected error message');
-            assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-version',
-                'expected error typed');
-            assert.end();
-        });
-
-        test('read unexpected version error for undefined bits of strict', function t(assert) {
-            var buffer = new Buffer([
-                0x81,                   // strict XXX BUT WHAT IS GOING ON WITH THIS LOW BIT!?
-                0x01,                   // version = 1
-                0x00,                   // shrug
-                0x01,                   // type = CALL
-                0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
-                0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
-                0x00, 0x00, 0x00, 0x00, // id:4 = 0
-                                        // body
-                0x0c,                   // struct
-                0x00, 0x01,             // field 1
-                0x08,                   // i32
-                0x00, 0x01,             // field 1
-                0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-                0x00,                   // end of foo
-                0x00                    // end of result
-            ]);
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-            assert.equal(result.err.message, 'unrecognized Thrift message envelope version: 257',
-                'expected error message');
-            assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-version',
-                'expected error typed');
-            assert.end();
-        });
-
-        test('read unrecognized message type error (strict)', function t(assert) {
-            var buffer = new Buffer([
-                0x80,                   // strict
-                0x01,                   // version = 1
-                0x00,                   // shrug
-                0xff,                   // type = XXX WAT!?
-                0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
-                0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
-                0x00, 0x00, 0x00, 0x00, // id:4 = 0
-                                        // body
-                0x0c,                   // struct
-                0x00, 0x01,             // field 1
-                0x08,                   // i32
-                0x00, 0x01,             // field 1
-                0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-                0x00,                   // end of foo
-                0x00                    // end of result
-            ]);
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-            assert.equal(result.err.message, 'unrecognized Thrift message envelope type: 255',
-                'expected error message');
-            assert.equal(result.err.value, 255,
-                'expected error value');
-            assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-type',
-                'expected error type');
-            assert.end();
-        });
-
-        test('read unrecognized message type error (legacy)', function t(assert) {
-            var buffer = new Buffer([
-                0x00, 0x00, 0x00, 0x03, // name.length:4
-                0x66, 0x6f, 0x6f,       // name:name.length
-                0xff,                   // type:1 = XXX WAT!?
-                0x00, 0x00, 0x00, 0x00, // id:4
-                                        // body
-                0x0c,                   // struct
-                0x00, 0x01,             // field 1
-                0x08,                   // i32
-                0x00, 0x01,             // field 1
-                0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-                0x00,                   // end of foo
-                0x00                    // end of result
-            ]);
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-            assert.equal(result.err.message, 'unrecognized Thrift message envelope type: 255',
-                'expected error message');
-            assert.equal(result.err.value, 255,
-                'expected error value');
-            assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-type',
-                'expected error type');
-            assert.end();
-        });
-
-        test('read invalid message body error', function t(assert) {
-            var buffer = new Buffer([
-                0x00, 0x00, 0x00, 0x03, // name.length:4
-                0x66, 0x6f, 0x6f,       // name:name.length
-                0x01,                   // type:1 = CALL
-                0x00, 0x00, 0x00, 0x00, // id:4
-                                        // body
-                0x00, 0x02,             // field 1 -- XXX there is no field 2
-                0x08,                   // i32
-                0x00, 0x01,             // field 1
-                0x00, 0x00, 0x00, 0x0a, // number:4 = 10
-                0x00,                   // end of foo
-                0x00                    // end of result
-            ]);
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-            assert.equal(result.err.message, 'missing required field "bar" with id 1 on foo_args',
-                'expected message');
-            assert.end();
-        });
-
-        test('read exception', function t(assert) {
-            var buffer = new Buffer([
-                0x00, 0x00, 0x00, 0x03, // name.length:4
-                0x66, 0x6f, 0x6f,       // name:name.length
-                0x03,                   // type:3 = EXCEPTION
-                0x00, 0x00, 0x00, 0x00, // id:4
-                                        // exception
-                0x0b,                   // typeid:1 -- 11 -- STRING
-                0x00, 0x01,             // fieldid:2 -- 1 -- message
-                0x00, 0x00, 0x00, 0x10, // length
-                0x55, 0x6e, 0x65, 0x78,
-                0x70, 0x65, 0x63, 0x74,
-                0x65, 0x64, 0x20, 0x65,
-                0x72, 0x72, 0x6f, 0x72, // "Unexpected error"
-                0x08,                   // typeid:1 -- 8 -- i32
-                0x00, 0x02,             // fieldid:2 -- 2 -- type
-                0x00, 0x00, 0x00, 0x00, // type:4 -- 0 -- UNKNOWN
-                0x00,                   // end of struct
-            ]);
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-            assert.equal(result.err.message, 'Unexpected error',
-                'expected message');
-            assert.equal(result.err.type, 'UNKNOWN',
-                'expected message');
-            assert.end();
-        });
-
-        test('read invalid exception', function t(assert) {
-            var buffer = new Buffer([
-                0x00, 0x00, 0x00, 0x03, // name.length:4
-                0x66, 0x6f, 0x6f,       // name:name.length
-                0x03,                   // type:3 = EXCEPTION
-                0x00, 0x00, 0x00, 0x00, // id:4
-                                        // exception
-                0x08,                   // typeid:1 -- 8, i32 XXX invalid
-                0x00, 0x01,             // fieldid:2 -- 1 -- message
-                // ...
-            ]);
-            var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
-            assert.equal(result.err.message,
-                'unexpected typeid 8 (I32) for field "message" with id 1 on ' +
-                'ThriftMessageEnvelopeException; expected 11 (STRING)',
-                'expected error'
-            );
-            assert.end();
-        });
-
-        test('write invalid message type (legacy)', function t(assert) {
-            var buffer = new Buffer(255);
-            var message = {
-                name: 'foo',
-                type: 'BORK',
-                version: 0
-            };
-            var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
-            assert.equal(result.err.message, 'invalid Thrift message envelope type name: BORK',
-                'expected message');
-            assert.end();
-        });
-
-        test('write invalid message type (strict)', function t(assert) {
-            var buffer = new Buffer(255);
-            var message = {
-                name: 'foo',
-                type: 'BORK',
-                version: 1
-            };
-            var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
-            assert.equal(result.err.message, 'invalid Thrift message envelope type name: BORK',
-                'expected message');
-            assert.end();
-        });
-
-        test('measure byte length for invalid body', function t(assert) {
-            var buffer = new Buffer(255);
-            var message = {
-                name: 'foo',
-                type: 'BORK',
-                version: 1,
-                body: {
-                    bar: {
-                        number: null
-                    }
-                }
-            };
-            var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
-            assert.equal(result.err.message, 'missing required field "number" with id 1 on Struct',
-                'expected message');
-            assert.end();
-        });
-
-        test('measure byte length for invalid exception', function t(assert) {
-            var buffer = new Buffer(255);
-            var message = {
-                name: 'foo',
-                type: 'EXCEPTION',
-                body: {
-                    message: 10
-                }
-            };
-            var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
-            assert.equal(result.err.message, 'invalid argument, expected string, null, or undefined',
-                'expected message');
-            assert.end();
-        });
+    var message = new thrift.Service.foo.ArgumentsMessage({
+        id: 0,
+        body: new thrift.Service.foo.Arguments({
+            bar: new thrift.Struct({
+                number: 10
+            })
+        })
     });
 
+    var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
+    var buffer = new Buffer(result.length);
+
+    var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
+
+    var expectedBuffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0x01,                   // type:1 = CALL
+        0x00, 0x00, 0x00, 0x00, // id:4
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00,                   // end of foo
+        0x00                    // end of result
+    ]);
+    assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
+
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+
+    assert.deepEqual(result.value, message, 'read correctly');
+
+    assert.end();
+});
+
+test('round-trip a non-strict message', function t(assert) {
+    var message = new thrift.Service.foo.ArgumentsMessage({
+        version: 1,
+        id: 0,
+        body: new thrift.Service.foo.Arguments({
+            bar: new thrift.Struct({
+                number: 10
+            })
+        })
+    });
+
+    var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
+    var buffer = new Buffer(result.length);
+    var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
+
+    var expectedBuffer = new Buffer([
+        0x80,                   // strict
+        0x01,                   // version = 1
+        0x00,                   // shrug
+        0x01,                   // type = CALL
+        0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
+        0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
+        0x00, 0x00, 0x00, 0x00, // id:4 = 0
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00,                   // end of foo
+        0x00                    // end of result
+    ]);
+    assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
+
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+
+    assert.deepEqual(result.value, message, 'read correctly');
+
+    assert.end();
+});
+
+test('round trip an exception (legacy)', function t(assert) {
+    // TODO exercise version=1
+    var message = new thrift.Service.foo.ResultMessage({
+        id: 2,
+        type: 'EXCEPTION',
+        body: new thrift.exception.Constructor({
+            message: 'Unknown method',
+            type: 'UNKNOWN_METHOD'
+        })
+    });
+
+    var expectedBuffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f,       // name:name.length -- "foo"
+        0x03,                   // type:3 = EXCEPTION
+        0x00, 0x00, 0x00, 0x02, // id:4 -- 2
+                                // exception
+        0x0b,                   // typeid:1 -- 11 -- STRING
+        0x00, 0x01,             // fieldid:2 -- 1 -- message
+        0x00, 0x00, 0x00, 0x0e, // length
+        0x55, 0x6e, 0x6b, 0x6e,
+        0x6f, 0x77, 0x6e, 0x20,
+        0x6d, 0x65, 0x74, 0x68,
+        0x6f, 0x64,
+        0x08,                   // typeid:1 -- 8 -- i32
+        0x00, 0x02,             // fieldid:2 -- 2 -- type
+        0x00, 0x00, 0x00, 0x01, // type:4 -- 1 -- UNKNOWN_METHOD
+        0x00                    // end of struct
+    ]);
+
+    var result = thrift.Service.foo.resultMessageRW.byteLength(message);
+    assert.equal(result.length, expectedBuffer.length, 'measured correctly');
+
+    var buffer = new Buffer(result.length);
+    buffer.fill(0xCC);
+
+    var result = thrift.Service.foo.resultMessageRW.writeInto(message, buffer, 0);
+    if (result.err) return assert.end(result.err);
+
+    assert.deepEqual(buffer, expectedBuffer, 'wrote correctly');
+
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+
+    assert.deepEqual(result.err, message.body, 'produced proper error');
+    assert.deepEqual(result.value, message, 'read correctly');
+
+    assert.end();
+});
+
+test('read unexpected version error', function t(assert) {
+    var buffer = new Buffer([
+        0x80,                   // strict
+        0x02,                   // version = 2 XXX BUT WHAT IS GOING ON WITH VERSION 2!?
+        0x00,                   // shrug
+        0x01,                   // type = CALL
+        0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
+        0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
+        0x00, 0x00, 0x00, 0x00, // id:4 = 0
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00,                   // end of foo
+        0x00                    // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'unrecognized Thrift message envelope version: 2',
+        'expected error message');
+    assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-version',
+        'expected error typed');
+    assert.end();
+});
+
+test('read unexpected version error for undefined bits of strict', function t(assert) {
+    var buffer = new Buffer([
+        0x81,                   // strict XXX BUT WHAT IS GOING ON WITH THIS LOW BIT!?
+        0x01,                   // version = 1
+        0x00,                   // shrug
+        0x01,                   // type = CALL
+        0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
+        0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
+        0x00, 0x00, 0x00, 0x00, // id:4 = 0
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00,                   // end of foo
+        0x00                    // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'unrecognized Thrift message envelope version: 257',
+        'expected error message');
+    assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-version',
+        'expected error typed');
+    assert.end();
+});
+
+test('read unrecognized message type error (strict)', function t(assert) {
+    var buffer = new Buffer([
+        0x80,                   // strict
+        0x01,                   // version = 1
+        0x00,                   // shrug
+        0xff,                   // type = XXX WAT!?
+        0x00, 0x00, 0x00, 0x03, // name.length:4 = 3
+        0x66, 0x6f, 0x6f,       // name:name.length = 'foo'
+        0x00, 0x00, 0x00, 0x00, // id:4 = 0
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00,                   // end of foo
+        0x00                    // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'unrecognized Thrift message envelope type: 255',
+        'expected error message');
+    assert.equal(result.err.value, 255,
+        'expected error value');
+    assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-type',
+        'expected error type');
+    assert.end();
+});
+
+test('read unrecognized message type error (legacy)', function t(assert) {
+    var buffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0xff,                   // type:1 = XXX WAT!?
+        0x00, 0x00, 0x00, 0x00, // id:4
+                                // body
+        0x0c,                   // struct
+        0x00, 0x01,             // field 1
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00,                   // end of foo
+        0x00                    // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'unrecognized Thrift message envelope type: 255',
+        'expected error message');
+    assert.equal(result.err.value, 255,
+        'expected error value');
+    assert.equal(result.err.type, 'thrift-unrecognized-message-envelope-type',
+        'expected error type');
+    assert.end();
+});
+
+test('read invalid message body error', function t(assert) {
+    var buffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0x01,                   // type:1 = CALL
+        0x00, 0x00, 0x00, 0x00, // id:4
+                                // body
+        0x00, 0x02,             // field 1 -- XXX there is no field 2
+        0x08,                   // i32
+        0x00, 0x01,             // field 1
+        0x00, 0x00, 0x00, 0x0a, // number:4 = 10
+        0x00,                   // end of foo
+        0x00                    // end of result
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'missing required field "bar" with id 1 on foo_args',
+        'expected message');
+    assert.end();
+});
+
+test('read exception', function t(assert) {
+    var buffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0x03,                   // type:3 = EXCEPTION
+        0x00, 0x00, 0x00, 0x00, // id:4
+                                // exception
+        0x0b,                   // typeid:1 -- 11 -- STRING
+        0x00, 0x01,             // fieldid:2 -- 1 -- message
+        0x00, 0x00, 0x00, 0x10, // length
+        0x55, 0x6e, 0x65, 0x78,
+        0x70, 0x65, 0x63, 0x74,
+        0x65, 0x64, 0x20, 0x65,
+        0x72, 0x72, 0x6f, 0x72, // "Unexpected error"
+        0x08,                   // typeid:1 -- 8 -- i32
+        0x00, 0x02,             // fieldid:2 -- 2 -- type
+        0x00, 0x00, 0x00, 0x00, // type:4 -- 0 -- UNKNOWN
+        0x00,                   // end of struct
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message, 'Unexpected error',
+        'expected message');
+    assert.equal(result.err.type, 'UNKNOWN',
+        'expected message');
+    assert.end();
+});
+
+test('read invalid exception', function t(assert) {
+    var buffer = new Buffer([
+        0x00, 0x00, 0x00, 0x03, // name.length:4
+        0x66, 0x6f, 0x6f,       // name:name.length
+        0x03,                   // type:3 = EXCEPTION
+        0x00, 0x00, 0x00, 0x00, // id:4
+                                // exception
+        0x08,                   // typeid:1 -- 8, i32 XXX invalid
+        0x00, 0x01,             // fieldid:2 -- 1 -- message
+        // ...
+    ]);
+    var result = thrift.Service.foo.argumentsMessageRW.readFrom(buffer, 0);
+    assert.equal(result.err.message,
+        'unexpected typeid 8 (I32) for field "message" with id 1 on ' +
+        'ThriftMessageEnvelopeException; expected 11 (STRING)',
+        'expected error'
+    );
+    assert.end();
+});
+
+test('write invalid message type (legacy)', function t(assert) {
+    var buffer = new Buffer(255);
+    var message = {
+        name: 'foo',
+        type: 'BORK',
+        version: 0
+    };
+    var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
+    assert.equal(result.err.message, 'invalid Thrift message envelope type name: BORK',
+        'expected message');
+    assert.end();
+});
+
+test('write invalid message type (strict)', function t(assert) {
+    var buffer = new Buffer(255);
+    var message = {
+        name: 'foo',
+        type: 'BORK',
+        version: 1
+    };
+    var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
+    assert.equal(result.err.message, 'invalid Thrift message envelope type name: BORK',
+        'expected message');
+    assert.end();
+});
+
+test('measure byte length for invalid body', function t(assert) {
+    var buffer = new Buffer(255);
+    var message = {
+        name: 'foo',
+        type: 'BORK',
+        version: 1,
+        body: {
+            bar: {
+                number: null
+            }
+        }
+    };
+    var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
+    assert.equal(result.err.message, 'missing required field "number" with id 1 on Struct',
+        'expected message');
+    assert.end();
+});
+
+test('measure byte length for invalid exception', function t(assert) {
+    var buffer = new Buffer(255);
+    var message = {
+        name: 'foo',
+        type: 'EXCEPTION',
+        body: {
+            message: 10
+        }
+    };
+    var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
+    assert.equal(result.err.message, 'invalid argument, expected string, null, or undefined',
+        'expected message');
+    assert.end();
 });

--- a/test/recursion.js
+++ b/test/recursion.js
@@ -22,85 +22,75 @@
 
 var test = require('tape');
 var testRW = require('bufrw/test_rw');
+
+var Thrift = require('../thrift').Thrift;
 var fs = require('fs');
 var path = require('path');
-var withLoader = require('./loader');
+var source = fs.readFileSync(path.join(__dirname, 'recursion.thrift'), 'ascii');
+var thrift = new Thrift({source: source});
+var Shark = thrift.Shark;
 
-withLoader(function (loadThrift, test) {
+test('recursive rw', testRW.cases(Shark.rw, [
 
-    var source = fs.readFileSync(path.join(__dirname, 'recursion.thrift'), 'ascii');
-    loadThrift({source: source}, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
+    [new Shark(), [
+        0x00 // type:1 -- 0 -- stop
+    ]],
 
-        var Shark = thrift.Shark;
+    [new Shark({left: new Shark(), right: new Shark()}), [
+        0x0c,       // type:1 -- 12 -- STRUCT
+        0x00, 0x02, // id:2   -- 2  -- left
+        0x00,       // typeid -- 0  -- STOP
+        0x0c,       // type:1 -- 12 -- STRUCT
+        0x00, 0x03, // id:2   -- 3  -- right
+        0x00,       // typeid -- 0  -- STOP
+        0x00        // type:1 -- 0  -- STOP
+    ]],
 
-        test('recursive rw', testRW.cases(Shark.rw, [
+    [new Shark({name: 'Katie'}), [
+        0x0b,                         // type:1  -- 11 -- STRING
+        0x00, 0x01,                   // id:2    -- 1  -- name
+        0x00, 0x00, 0x00, 0x05,       // name~4  -- 5
+        0x4b, 0x61, 0x74, 0x69, 0x65, // 'Katie'
+        0x00                          // type:1  -- 0  -- STOP
+    ]],
 
-            [new Shark(), [
-                0x00 // type:1 -- 0 -- stop
-            ]],
+    [new Shark({name: 'Katie', left: new Shark()}), [
+        0x0b,                         // type:1  -- 11 -- STRING
+        0x00, 0x01,                   // id:2    -- 1  -- name
+        0x00, 0x00, 0x00, 0x05,       // name~4  -- 5
+        0x4b, 0x61, 0x74, 0x69, 0x65, // 'Katie'
+        0x0c,                         // type:1  -- 12 -- STRUCT
+        0x00, 0x02,                   // id:2    -- 2  -- left
+        0x00,                         // typeid  -- 0  -- STOP
+        0x00                          // type:1  -- 0  -- STOP
+    ]],
 
-            [new Shark({left: new Shark(), right: new Shark()}), [
-                0x0c,       // type:1 -- 12 -- STRUCT
-                0x00, 0x02, // id:2   -- 2  -- left
-                0x00,       // typeid -- 0  -- STOP
-                0x0c,       // type:1 -- 12 -- STRUCT
-                0x00, 0x03, // id:2   -- 3  -- right
-                0x00,       // typeid -- 0  -- STOP
-                0x00        // type:1 -- 0  -- STOP
-            ]],
+    [new Shark({name: 'Katie', right: new Shark({right: new Shark()})}), [
+        0x0b,                         // type:1  -- 11 -- STRING
+        0x00, 0x01,                   // id:2    -- 1  -- name
+        0x00, 0x00, 0x00, 0x05,       // name~4  -- 5
+        0x4b, 0x61, 0x74, 0x69, 0x65, // 'Katie'
+        0x0c,                         // type:1  -- 12 -- STRUCT
+        0x00, 0x03,                   // id:2    -- 3  -- right
+        0x0c,                         // type:1  -- 12 -- STRUCT
+        0x00, 0x03,                   // id:2    -- 3  -- right
+        0x00,                         // typeid  -- 0  -- STOP
+        0x00,                         // typeid  -- 0  -- STOP
+        0x00                          // type:1  -- 0  -- STOP
+    ]],
 
-            [new Shark({name: 'Katie'}), [
-                0x0b,                         // type:1  -- 11 -- STRING
-                0x00, 0x01,                   // id:2    -- 1  -- name
-                0x00, 0x00, 0x00, 0x05,       // name~4  -- 5
-                0x4b, 0x61, 0x74, 0x69, 0x65, // 'Katie'
-                0x00                          // type:1  -- 0  -- STOP
-            ]],
-
-            [new Shark({name: 'Katie', left: new Shark()}), [
-                0x0b,                         // type:1  -- 11 -- STRING
-                0x00, 0x01,                   // id:2    -- 1  -- name
-                0x00, 0x00, 0x00, 0x05,       // name~4  -- 5
-                0x4b, 0x61, 0x74, 0x69, 0x65, // 'Katie'
-                0x0c,                         // type:1  -- 12 -- STRUCT
-                0x00, 0x02,                   // id:2    -- 2  -- left
-                0x00,                         // typeid  -- 0  -- STOP
-                0x00                          // type:1  -- 0  -- STOP
-            ]],
-
-            [new Shark({name: 'Katie', right: new Shark({right: new Shark()})}), [
-                0x0b,                         // type:1  -- 11 -- STRING
-                0x00, 0x01,                   // id:2    -- 1  -- name
-                0x00, 0x00, 0x00, 0x05,       // name~4  -- 5
-                0x4b, 0x61, 0x74, 0x69, 0x65, // 'Katie'
-                0x0c,                         // type:1  -- 12 -- STRUCT
-                0x00, 0x03,                   // id:2    -- 3  -- right
-                0x0c,                         // type:1  -- 12 -- STRUCT
-                0x00, 0x03,                   // id:2    -- 3  -- right
-                0x00,                         // typeid  -- 0  -- STOP
-                0x00,                         // typeid  -- 0  -- STOP
-                0x00                          // type:1  -- 0  -- STOP
-            ]],
-
-            {
-                readTest: {
-                    bytes: [
-                        0x0b,      // type:1 -- 11 -- STRING
-                        0x00, 0x02 // id:2   -- 2  -- left
-                    ],
-                    error: {
-                        type: 'thrift-unexpected-field-value-typeid',
-                        name: 'ThriftUnexpectedFieldValueTypeidError',
-                        message:
-                            'unexpected typeid 11 (STRING) for field "left" with id 2 on Shark; expected 12 (STRUCT)'
-                    }
-                }
+    {
+        readTest: {
+            bytes: [
+                0x0b,      // type:1 -- 11 -- STRING
+                0x00, 0x02 // id:2   -- 2  -- left
+            ],
+            error: {
+                type: 'thrift-unexpected-field-value-typeid',
+                name: 'ThriftUnexpectedFieldValueTypeidError',
+                message: 'unexpected typeid 11 (STRING) for field "left" with id 2 on Shark; expected 12 (STRUCT)'
             }
+        }
+    }
 
-        ]));
-    });
-
-});
+]));

--- a/test/recursion.js
+++ b/test/recursion.js
@@ -20,15 +20,20 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
+withLoader(function (loadThrift, test) {
 
-    var fs = require('fs');
-    var path = require('path');
     var source = fs.readFileSync(path.join(__dirname, 'recursion.thrift'), 'ascii');
     loadThrift({source: source}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
+
         var Shark = thrift.Shark;
 
         test('recursive rw', testRW.cases(Shark.rw, [
@@ -97,4 +102,5 @@ module.exports = function(loadThrift) {
 
         ]));
     });
-}
+
+});

--- a/test/service.js
+++ b/test/service.js
@@ -20,14 +20,19 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
+withLoader(function (loadThrift, test) {
 
-    var fs = require('fs');
-    var path = require('path');
     var source = fs.readFileSync(path.join(__dirname, 'service.thrift'), 'ascii');
+
     loadThrift({source: source, strict: false}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
+
         test('has args', function t(assert) {
             assert.ok(thrift.getType('Foo::foo_args'), 'has args');
             assert.ok(thrift.Foo.foo.args, 'has args exposed on service object');
@@ -102,4 +107,5 @@ module.exports = function(loadThrift) {
             });
         });
     });
-}
+
+});

--- a/test/service.js
+++ b/test/service.js
@@ -20,92 +20,87 @@
 
 'use strict';
 
+var test = require('tape');
+
+var Thrift = require('../thrift').Thrift;
 var fs = require('fs');
 var path = require('path');
-var withLoader = require('./loader');
+var source = fs.readFileSync(path.join(__dirname, 'service.thrift'), 'ascii');
+var thrift = new Thrift({source: source, strict: false});
 
-withLoader(function (loadThrift, test) {
+test('has args', function t(assert) {
+    assert.ok(thrift.getType('Foo::foo_args'), 'has args');
+    assert.ok(thrift.Foo.foo.args, 'has args exposed on service object');
+    assert.end();
+});
 
-    var source = fs.readFileSync(path.join(__dirname, 'service.thrift'), 'ascii');
+test('void function has no success in result struct', function t(assert) {
+    var result = thrift.getType('Foo::bar_result');
+    assert.deepEqual(Object.keys(result.fieldsById), ['1'], 'only exception id');
+    assert.deepEquals(Object.keys(result.fieldsByName), ['barError'], 'only exception name');
+    assert.end();
+});
 
-    loadThrift({source: source, strict: false}, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
+test('non-void function has success in result struct', function t(assert) {
+    var result = thrift.getType('Foo::foo_result');
+    assert.deepEqual(Object.keys(result.fieldsById), ['0', '1'], 'success and error ids');
+    assert.deepEquals(Object.keys(result.fieldsByName), ['success', 'fail'], 'success and error field names');
+    assert.end();
+});
 
-        test('has args', function t(assert) {
-            assert.ok(thrift.getType('Foo::foo_args'), 'has args');
-            assert.ok(thrift.Foo.foo.args, 'has args exposed on service object');
-            assert.end();
-        });
+test('returns base-type that is not void', function t(assert) {
+    var result = thrift.getType('Foo::returnsI32_result');
+    assert.deepEqual(Object.keys(result.fieldsById), ['0'], 'success id');
+    assert.deepEquals(Object.keys(result.fieldsByName), ['success'], 'success name');
+    assert.end();
+});
 
-        test('void function has no success in result struct', function t(assert) {
-            var result = thrift.getType('Foo::bar_result');
-            assert.deepEqual(Object.keys(result.fieldsById), ['1'], 'only exception id');
-            assert.deepEquals(Object.keys(result.fieldsByName), ['barError'], 'only exception name');
-            assert.end();
-        });
+test('returns non-base-type', function t(assert) {
+    var result = thrift.getType('Foo::returnsStruct_result');
+    assert.deepEqual(Object.keys(result.fieldsById), ['0'], 'success id');
+    assert.deepEquals(Object.keys(result.fieldsByName), ['success'], 'success name');
+    assert.end();
+});
 
-        test('non-void function has success in result struct', function t(assert) {
-            var result = thrift.getType('Foo::foo_result');
-            assert.deepEqual(Object.keys(result.fieldsById), ['0', '1'], 'success and error ids');
-            assert.deepEquals(Object.keys(result.fieldsByName), ['success', 'fail'], 'success and error field names');
-            assert.end();
-        });
+test('service extends from another service', function t(assert) {
+    assert.deepEqual(
+        Object.keys(thrift.Qux),
+        ['quux', 'foo', 'bar', 'returnsI32', 'returnsStruct'],
+        'Service contains function from BaseService'
+    );
 
-        test('returns base-type that is not void', function t(assert) {
-            var result = thrift.getType('Foo::returnsI32_result');
-            assert.deepEqual(Object.keys(result.fieldsById), ['0'], 'success id');
-            assert.deepEquals(Object.keys(result.fieldsByName), ['success'], 'success name');
-            assert.end();
-        });
+    assert.deepEqual(
+        Object.keys(thrift.Corge),
+        ['grault', 'quux', 'foo', 'bar', 'returnsI32', 'returnsStruct'],
+        'Service contains function from BaseService'
+    );
 
-        test('returns non-base-type', function t(assert) {
-            var result = thrift.getType('Foo::returnsStruct_result');
-            assert.deepEqual(Object.keys(result.fieldsById), ['0'], 'success id');
-            assert.deepEquals(Object.keys(result.fieldsByName), ['success'], 'success name');
-            assert.end();
-        });
+    assert.deepEqual(
+        Object.keys(thrift.Garply),
+        ['waldo', 'quux', 'foo', 'bar', 'returnsI32', 'returnsStruct'],
+        'Service contains function from BaseService'
+    );
 
-        test('service extends from another service', function t(assert) {
-            assert.deepEqual(
-                Object.keys(thrift.Qux),
-                ['quux', 'foo', 'bar', 'returnsI32', 'returnsStruct'],
-                'Service contains function from BaseService'
-            );
+    assert.equal(
+        thrift.Qux.foo,
+        thrift.Foo.foo,
+        'Function Qux.foo is the same as Foo.foo by reference'
+    );
 
-            assert.deepEqual(
-                Object.keys(thrift.Corge),
-                ['grault', 'quux', 'foo', 'bar', 'returnsI32', 'returnsStruct'],
-                'Service contains function from BaseService'
-            );
+    assert.end();
+});
 
-            assert.deepEqual(
-                Object.keys(thrift.Garply),
-                ['waldo', 'quux', 'foo', 'bar', 'returnsI32', 'returnsStruct'],
-                'Service contains function from BaseService'
-            );
+test('service extends throws on duplicate function name', function t(assert) {
+    assert.throws(
+        duplicateFunction,
+        /Foo.bar already inherited from baseService/,
+        'Service extends throws if function with same name already exists'
+    );
 
-            assert.equal(
-                thrift.Qux.foo,
-                thrift.Foo.foo,
-                'Function Qux.foo is the same as Foo.foo by reference'
-            );
+    function duplicateFunction() {
+        var source = fs.readFileSync(path.join(__dirname, 'service-duplicate-function-error.thrift'), 'ascii');
+        return new Thrift({source: source});
+    }
 
-            assert.end();
-        });
-
-        test('service extends throws on duplicate function name', function t(assert) {
-            var source = fs.readFileSync(path.join(__dirname, 'service-duplicate-function-error.thrift'), 'ascii');
-            loadThrift({source: source}, function (err, thrift) {
-                assert.throws(
-                    function throws() { throw err; },
-                     /Foo.bar already inherited from baseService/,
-                    'Service extends throws if function with same name already exists'
-                );
-                assert.end();
-            });
-        });
-    });
-
+    assert.end();
 });

--- a/test/set.js
+++ b/test/set.js
@@ -26,8 +26,8 @@ var test = require('tape');
 var testRW = require('bufrw/test_rw');
 var fs = require('fs');
 var path = require('path');
-var withLoader = require('./loader');
 
+var Thrift = require('../thrift').Thrift;
 var ThriftSet = require('../set').ThriftSet;
 var ThriftString = require('../string').ThriftString;
 var ThriftI8 = require('../i8').ThriftI8;
@@ -122,78 +122,70 @@ test('ThriftSet.rw: set of strings as object', testRW.cases(stringObjectSet.rw, 
 
 ]));
 
-withLoader(function (loadThrift, test) {
-    var source = fs.readFileSync(path.join(__dirname, 'set.thrift'), 'ascii');
-    loadThrift({source: source}, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
+var source = fs.readFileSync(path.join(__dirname, 'set.thrift'), 'ascii');
+var thrift = new Thrift({source: source});
 
-        test('Struct with set rw', testRW.cases(thrift.Bucket.rw, [
+test('Struct with set rw', testRW.cases(thrift.Bucket.rw, [
 
-            [new thrift.Bucket({asArray: [1, 2, 3]}), [
-                0x0e,                   // type:1      -- 14, set
-                0x00, 0x01,             // field:2     -- 1, asArray
-                0x08,                   // type:1      -- 8, i32
-                0x00, 0x00, 0x00, 0x03, // len:4       -- 3
-                0x00, 0x00, 0x00, 0x01, // [0] value:4 -- 1
-                0x00, 0x00, 0x00, 0x02, // [1] value:4 -- 2
-                0x00, 0x00, 0x00, 0x03, // [2] value:4 -- 3
-                0x00                    // type:1      -- 0, stop
-            ]],
+    [new thrift.Bucket({asArray: [1, 2, 3]}), [
+        0x0e,                   // type:1      -- 14, set
+        0x00, 0x01,             // field:2     -- 1, asArray
+        0x08,                   // type:1      -- 8, i32
+        0x00, 0x00, 0x00, 0x03, // len:4       -- 3
+        0x00, 0x00, 0x00, 0x01, // [0] value:4 -- 1
+        0x00, 0x00, 0x00, 0x02, // [1] value:4 -- 2
+        0x00, 0x00, 0x00, 0x03, // [2] value:4 -- 3
+        0x00                    // type:1      -- 0, stop
+    ]],
 
-            [new thrift.Bucket({numbersAsObject: {1: true, 2: true, 3: true}}), [
-                0x0e,                   // type:1      -- 14, set
-                0x00, 0x02,             // field:2     -- 1, numbersAsObject
-                0x08,                   // type:1      -- 8, i32
-                0x00, 0x00, 0x00, 0x03, // len:4       -- 3
-                0x00, 0x00, 0x00, 0x01, // [0] value:4 -- 1
-                0x00, 0x00, 0x00, 0x02, // [1] value:4 -- 2
-                0x00, 0x00, 0x00, 0x03, // [2] value:4 -- 3
-                0x00                    // type:1      -- 0, stop
-            ]],
+    [new thrift.Bucket({numbersAsObject: {1: true, 2: true, 3: true}}), [
+        0x0e,                   // type:1      -- 14, set
+        0x00, 0x02,             // field:2     -- 1, numbersAsObject
+        0x08,                   // type:1      -- 8, i32
+        0x00, 0x00, 0x00, 0x03, // len:4       -- 3
+        0x00, 0x00, 0x00, 0x01, // [0] value:4 -- 1
+        0x00, 0x00, 0x00, 0x02, // [1] value:4 -- 2
+        0x00, 0x00, 0x00, 0x03, // [2] value:4 -- 3
+        0x00                    // type:1      -- 0, stop
+    ]],
 
-            [new thrift.Bucket({stringsAsObject: {1: true, 2: true, 3: true}}), [
-                0x0e,                   // type:1       -- 14, set
-                0x00, 0x03,             // field:2      -- 1, numbersAsObject
-                0x0b,                   // type:1       -- 11, string
-                0x00, 0x00, 0x00, 0x03, // length:4     -- 3
-                0x00, 0x00, 0x00, 0x01, // [0] length:4 -- 1
-                0x31,                   // [0] value:1  -- '1'
-                0x00, 0x00, 0x00, 0x01, // [1] length:4 -- 1
-                0x32,                   // [1] value:1  -- '2'
-                0x00, 0x00, 0x00, 0x01, // [2] length:4 -- 1
-                0x33,                   // [2] value:1  -- '3'
-                0x00                    // type:1       -- 0, stop
-            ]]
+    [new thrift.Bucket({stringsAsObject: {1: true, 2: true, 3: true}}), [
+        0x0e,                   // type:1       -- 14, set
+        0x00, 0x03,             // field:2      -- 1, numbersAsObject
+        0x0b,                   // type:1       -- 11, string
+        0x00, 0x00, 0x00, 0x03, // length:4     -- 3
+        0x00, 0x00, 0x00, 0x01, // [0] length:4 -- 1
+        0x31,                   // [0] value:1  -- '1'
+        0x00, 0x00, 0x00, 0x01, // [1] length:4 -- 1
+        0x32,                   // [1] value:1  -- '2'
+        0x00, 0x00, 0x00, 0x01, // [2] length:4 -- 1
+        0x33,                   // [2] value:1  -- '3'
+        0x00                    // type:1       -- 0, stop
+    ]]
 
-        ]));
+]));
 
-        test('Tolerance for lists on the wire', function t(assert) {
-            var buf = new Buffer([
-                0x0f,                   // type:1      -- 15, list
-                0x00, 0x01,             // field:2     -- 1, asArray
-                0x08,                   // type:1      -- 8, i32
-                0x00, 0x00, 0x00, 0x03, // len:4       -- 3
-                0x00, 0x00, 0x00, 0x01, // [0] value:4 -- 1
-                0x00, 0x00, 0x00, 0x02, // [1] value:4 -- 2
-                0x00, 0x00, 0x00, 0x03, // [2] value:4 -- 3
-                0x00                    // type:1      -- 0, stop
-            ]);
+test('Tolerance for lists on the wire', function t(assert) {
+    var buf = new Buffer([
+        0x0f,                   // type:1      -- 15, list
+        0x00, 0x01,             // field:2     -- 1, asArray
+        0x08,                   // type:1      -- 8, i32
+        0x00, 0x00, 0x00, 0x03, // len:4       -- 3
+        0x00, 0x00, 0x00, 0x01, // [0] value:4 -- 1
+        0x00, 0x00, 0x00, 0x02, // [1] value:4 -- 2
+        0x00, 0x00, 0x00, 0x03, // [2] value:4 -- 3
+        0x00                    // type:1      -- 0, stop
+    ]);
 
-            var res = thrift.Bucket.rw.readFrom(buf, 0);
+    var res = thrift.Bucket.rw.readFrom(buf, 0);
 
-            if (res.err) {
-                return assert.end(res.err);
-            }
+    if (res.err) {
+        return assert.end(res.err);
+    }
 
-            assert.deepEqual(res.value, new thrift.Bucket({
-                asArray: [1, 2, 3]
-            }));
+    assert.deepEqual(res.value, new thrift.Bucket({
+        asArray: [1, 2, 3]
+    }));
 
-            assert.end();
-        });
-    });
-
+    assert.end();
 });
-

--- a/test/skip.js
+++ b/test/skip.js
@@ -21,167 +21,164 @@
 /* global Buffer */
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var formatError = require('bufrw/interface').formatError;
+var skip = require('../skip').skipField;
+var ReadResult = require('bufrw/base').ReadResult;
 
-    var test = require('tape');
-    var formatError = require('bufrw/interface').formatError;
-    var skip = require('../skip').skipField;
-    var ReadResult = require('bufrw/base').ReadResult;
+test('skips a bool', createCase([
+    0x02, // typeid:1 -- 2, BOOL
+    0x01  // bool:1 -- 1, true
+]));
 
-    test('skips a bool', createCase([
-        0x02, // typeid:1 -- 2, BOOL
-        0x01  // bool:1 -- 1, true
-    ]));
+test('skips a byte', createCase([
+    0x03, // typeid:1 -- 3, BYTE
+    0x20  // byte:1 -- 32, ' '
+]));
 
-    test('skips a byte', createCase([
-        0x03, // typeid:1 -- 3, BYTE
-        0x20  // byte:1 -- 32, ' '
-    ]));
+test('skips a double', createCase([
+    0x04, // typeid:1 -- 4, DOUBLE
+    0x00, 0x00, 0x00, 0x00, // maybe this represents a number
+    0x00, 0x00, 0x00, 0x00
+]));
 
-    test('skips a double', createCase([
-        0x04, // typeid:1 -- 4, DOUBLE
-        0x00, 0x00, 0x00, 0x00, // maybe this represents a number
-        0x00, 0x00, 0x00, 0x00
-    ]));
+test('skips an i16', createCase([
+    0x06, // typeid:1 -- 6, I16
+    0x00, 0x00
+]));
 
-    test('skips an i16', createCase([
-        0x06, // typeid:1 -- 6, I16
-        0x00, 0x00
-    ]));
+test('skips a i32', createCase([
+    0x08, // typeid:1 -- 8, I32
+    0x00, 0x00, 0x00, 0x00
+]));
 
-    test('skips a i32', createCase([
-        0x08, // typeid:1 -- 8, I32
-        0x00, 0x00, 0x00, 0x00
-    ]));
+test('skips a i64', createCase([
+    0x0a, // typeid:1 -- 10, I64
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00
+]));
 
-    test('skips a i64', createCase([
-        0x0a, // typeid:1 -- 10, I64
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00
-    ]));
+test('skip a null string', createCase([
+    0x0b,                   // typeid:1 -- 11, STRING
+    0x00, 0x00, 0x00, 0x00  // str_len:4 -- 0
+]));
 
-    test('skip a null string', createCase([
-        0x0b,                   // typeid:1 -- 11, STRING
-        0x00, 0x00, 0x00, 0x00  // str_len:4 -- 0
-    ]));
+test('skip a string', createCase([
+    0x0b,                   // typeid:1 -- 11, STRING
+    0x00, 0x00, 0x00, 0x08, // str_len:4 -- 8
+    0x00, 0x00, 0x00, 0x00, // 8 null chars
+    0x00, 0x00, 0x00, 0x00
+]));
 
-    test('skip a string', createCase([
-        0x0b,                   // typeid:1 -- 11, STRING
-        0x00, 0x00, 0x00, 0x08, // str_len:4 -- 8
-        0x00, 0x00, 0x00, 0x00, // 8 null chars
-        0x00, 0x00, 0x00, 0x00
-    ]));
+test('skip a null struct', createCase([
+    0x0c,                   // typeid:1 -- 12, STRUCT
+    0x00                    // > typeid:0 -- 0, STOP
+]));
 
-    test('skip a null struct', createCase([
-        0x0c,                   // typeid:1 -- 12, STRUCT
-        0x00                    // > typeid:0 -- 0, STOP
-    ]));
+test('skip a struct with all the atoms', createCase([
+    0x0c,                   // typeid:1 -- 12, STRUCT
 
-    test('skip a struct with all the atoms', createCase([
-        0x0c,                   // typeid:1 -- 12, STRUCT
+    0x02,                   // typeid:1 -- 2, BOOL
+    0x00, 0x00,             // fid:2 -- 0
+    0x00,                   // bool:1 -- 0, false
 
-        0x02,                   // typeid:1 -- 2, BOOL
-        0x00, 0x00,             // fid:2 -- 0
-        0x00,                   // bool:1 -- 0, false
+    0x03,                   // typeid:1 -- 3, BYTE
+    0x00, 0x01,             // fid:2 -- 1
+    0x61,                   // byte:1 -- 61, 'a'
 
-        0x03,                   // typeid:1 -- 3, BYTE
-        0x00, 0x01,             // fid:2 -- 1
-        0x61,                   // byte:1 -- 61, 'a'
+    0x04,                   // typeid:1 -- 4, DOUBLE
+    0x00, 0x02,             // fid:2 -- 2
+    0x00, 0x00, 0x00, 0x00, // double:8
+    0x00, 0x00, 0x00, 0x00,
 
-        0x04,                   // typeid:1 -- 4, DOUBLE
-        0x00, 0x02,             // fid:2 -- 2
-        0x00, 0x00, 0x00, 0x00, // double:8
-        0x00, 0x00, 0x00, 0x00,
+    0x06,                   // typeid:1 -- 6, I16
+    0x00, 0x03,             // fid:2 -- 3
+    0x00, 0x00,             // i16:2
 
-        0x06,                   // typeid:1 -- 6, I16
-        0x00, 0x03,             // fid:2 -- 3
-        0x00, 0x00,             // i16:2
+    0x08,                   // typeid:1 -- 8, I32
+    0x00, 0x04,             // fid:2 -- 4
+    0x00, 0x00, 0x00, 0x00, // i32:4
 
-        0x08,                   // typeid:1 -- 8, I32
-        0x00, 0x04,             // fid:2 -- 4
-        0x00, 0x00, 0x00, 0x00, // i32:4
+    0x0a,                   // typeid:1 -- 10, I64
+    0x00, 0x05,             // fid:2 -- 5
+    0x00, 0x00, 0x00, 0x00, // i64:8
+    0x00, 0x00, 0x00, 0x00,
 
-        0x0a,                   // typeid:1 -- 10, I64
-        0x00, 0x05,             // fid:2 -- 5
-        0x00, 0x00, 0x00, 0x00, // i64:8
-        0x00, 0x00, 0x00, 0x00,
+    0x0b,                   // typeid:1 -- 11, STRING
+    0x00, 0x06,             // fid:2 -- 6
+    0x00, 0x00, 0x00, 0x04, // str_len:4 -- 8
+    0x00, 0x00, 0x00, 0x00, // 4 null chars
 
-        0x0b,                   // typeid:1 -- 11, STRING
-        0x00, 0x06,             // fid:2 -- 6
-        0x00, 0x00, 0x00, 0x04, // str_len:4 -- 8
-        0x00, 0x00, 0x00, 0x00, // 4 null chars
+    0x00                    // > typeid:0 -- 0, STOP
+]));
 
-        0x00                    // > typeid:0 -- 0, STOP
-    ]));
+test('skip structs of structs', createCase([
+    0x0c,       // typeid:1    -- 12, STRUCT
+    0x0c,       // > typeid:1  -- 12, STRUCT
+    0x00, 0x01, // > fid:2     -- 1
+    0x0c,       // >> typeid:1 -- 12, STRUCT
+    0x00, 0x01, // >> fid:2    -- 1
+    0x00,       // >> typeid:0 -- 0, STOP
+    0x00,       // > typeid:0  -- 0, STOP
+    0x00        // typeid:0    -- 0, STOP
+]));
 
-    test('skip structs of structs', createCase([
-        0x0c,       // typeid:1    -- 12, STRUCT
-        0x0c,       // > typeid:1  -- 12, STRUCT
-        0x00, 0x01, // > fid:2     -- 1
-        0x0c,       // >> typeid:1 -- 12, STRUCT
-        0x00, 0x01, // >> fid:2    -- 1
-        0x00,       // >> typeid:0 -- 0, STOP
-        0x00,       // > typeid:0  -- 0, STOP
-        0x00        // typeid:0    -- 0, STOP
-    ]));
+test('skip list of strings', createCase([
+    0x0f,                   // typeid:1  -- 15, LIST
+    0x0b,                   // vtypeid:1 -- 11, STRING
+    0x00, 0x00, 0x00, 0x02, // length:4  -- 2
 
-    test('skip list of strings', createCase([
-        0x0f,                   // typeid:1  -- 15, LIST
-        0x0b,                   // vtypeid:1 -- 11, STRING
-        0x00, 0x00, 0x00, 0x02, // length:4  -- 2
+    0x00, 0x00, 0x00, 0x04, // str_len:4 -- 4
+    0x61, 0x62, 0x63, 0x64, // 'abcd'
 
-        0x00, 0x00, 0x00, 0x04, // str_len:4 -- 4
-        0x61, 0x62, 0x63, 0x64, // 'abcd'
+    0x00, 0x00, 0x00, 0x03, // str_len:4 -- 3
+    0x41, 0x42, 0x43        // 'ABC'
+]));
 
-        0x00, 0x00, 0x00, 0x03, // str_len:4 -- 3
-        0x41, 0x42, 0x43        // 'ABC'
-    ]));
+test('skip set of strings', createCase([
+    0x0e,                   // typeid:1  -- 14, SET
+    0x0b,                   // vtypeid:1 -- 11, STRING
+    0x00, 0x00, 0x00, 0x02, // length:4  -- 2
 
-    test('skip set of strings', createCase([
-        0x0e,                   // typeid:1  -- 14, SET
-        0x0b,                   // vtypeid:1 -- 11, STRING
-        0x00, 0x00, 0x00, 0x02, // length:4  -- 2
+    0x00, 0x00, 0x00, 0x04, // str_len:4 -- 4
+    0x61, 0x62, 0x63, 0x64, // 'abcd'
 
-        0x00, 0x00, 0x00, 0x04, // str_len:4 -- 4
-        0x61, 0x62, 0x63, 0x64, // 'abcd'
+    0x00, 0x00, 0x00, 0x03, // str_len:4 -- 3
+    0x41, 0x42, 0x43        // 'ABC'
+]));
 
-        0x00, 0x00, 0x00, 0x03, // str_len:4 -- 3
-        0x41, 0x42, 0x43        // 'ABC'
-    ]));
+test('skip map of strings to i32s', createCase([
+    0x0d,                   // typeid:1  -- 13, MAP
+    0x0b,                   // ktypeid:1 -- 11, STRING
+    0x08,                   // vtypeid:1 -- 8, I32
+    0x00, 0x00, 0x00, 0x02, // length:4  -- 2
 
-    test('skip map of strings to i32s', createCase([
-        0x0d,                   // typeid:1  -- 13, MAP
-        0x0b,                   // ktypeid:1 -- 11, STRING
-        0x08,                   // vtypeid:1 -- 8, I32
-        0x00, 0x00, 0x00, 0x02, // length:4  -- 2
+    0x00, 0x00, 0x00, 0x04, // key[0] str_len:4 -- 4
+    0x61, 0x62, 0x63, 0x64, // key[0] 'abcd'
+    0x00, 0x00, 0x00, 0x01, // val[0] num~4 -- 1
 
-        0x00, 0x00, 0x00, 0x04, // key[0] str_len:4 -- 4
-        0x61, 0x62, 0x63, 0x64, // key[0] 'abcd'
-        0x00, 0x00, 0x00, 0x01, // val[0] num~4 -- 1
+    0x00, 0x00, 0x00, 0x03, // key[1] str_len:4 -- 3
+    0x41, 0x42, 0x43,       // key[1] 'ABC'
+    0x00, 0x00, 0x00, 0x02  // val[1] num~4 -- 2
+]));
 
-        0x00, 0x00, 0x00, 0x03, // key[1] str_len:4 -- 3
-        0x41, 0x42, 0x43,       // key[1] 'ABC'
-        0x00, 0x00, 0x00, 0x02  // val[1] num~4 -- 2
-    ]));
-
-    function createCase(bytes) {
-        return function t(assert) {
-            var res = new ReadResult();
-            var result = skip(res, new Buffer(bytes), 0);
-            if (result.err) {
-                assert.comment(formatError(result.err), {color: true});
-                return assert.end(result.err);
-            }
-            assert.equal(result.offset, bytes.length, 'stops at end of buffer');
-            assert.end();
-        };
-    }
-
-    test('skip short buffer', function t(assert) {
-        var bytes = [];
+function createCase(bytes) {
+    return function t(assert) {
         var res = new ReadResult();
         var result = skip(res, new Buffer(bytes), 0);
-        assert.ok(result.err !== null);
+        if (result.err) {
+            assert.comment(formatError(result.err), {color: true});
+            return assert.end(result.err);
+        }
+        assert.equal(result.offset, bytes.length, 'stops at end of buffer');
         assert.end();
-    });
+    };
 }
+
+test('skip short buffer', function t(assert) {
+    var bytes = [];
+    var res = new ReadResult();
+    var result = skip(res, new Buffer(bytes), 0);
+    assert.ok(result.err !== null);
+    assert.end();
+});

--- a/test/string.js
+++ b/test/string.js
@@ -20,31 +20,28 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var testThrift = require('./thrift-test');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var testThrift = require('./thrift-test');
+var thriftrw = require('../index');
+var StringRW = thriftrw.StringRW;
+var ThriftString = thriftrw.ThriftString;
+var TYPE = require('../TYPE');
 
-    var thriftrw = require('../index');
-    var StringRW = thriftrw.StringRW;
-    var ThriftString = thriftrw.ThriftString;
-    var TYPE = require('../TYPE');
+var validTestCases = [
+    ['', [
+        0x00, 0x00, 0x00, 0x00
+    ]],
+    ['cat', [
+        0x00, 0x00, 0x00, 0x03, // len: 3
+        0x63, 0x61, 0x74        // chars  -- "cat"
+    ]]
+];
 
-    var validTestCases = [
-        ['', [
-            0x00, 0x00, 0x00, 0x00
-        ]],
-        ['cat', [
-            0x00, 0x00, 0x00, 0x03, // len: 3
-            0x63, 0x61, 0x74        // chars  -- "cat"
-        ]]
-    ];
+var testCases = [].concat(
+    validTestCases
+);
 
-    var testCases = [].concat(
-        validTestCases
-    );
-
-    test('StringRW', testRW.cases(StringRW, testCases));
-    test('ThriftString', testThrift(ThriftString, StringRW, TYPE.STRING));
-}
+test('StringRW', testRW.cases(StringRW, testCases));
+test('ThriftString', testThrift(ThriftString, StringRW, TYPE.STRING));

--- a/test/struct-skip.js
+++ b/test/struct-skip.js
@@ -20,153 +20,147 @@
 
 'use strict';
 
+var test = require('tape');
+
 var Buffer = require('buffer').Buffer;
+var Thrift = require('../thrift').Thrift;
 var fs = require('fs');
 var path = require('path');
-var withLoader = require('./loader');
+var source = fs.readFileSync(path.join(__dirname, 'struct.thrift'), 'ascii');
+var thrift = new Thrift({source: source});
 
-withLoader(function (loadThrift, test) {
-    var source = fs.readFileSync(path.join(__dirname, 'struct.thrift'), 'ascii');
-    loadThrift({source: source}, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
+var Health = thrift.$Health;
 
-        var Health = thrift.$Health;
+test('skip void', function t(assert) {
+    var result = Health.rw.readFrom(new Buffer([
+        0x02,                     // type:1   -- 2 -- BOOL
+        0x00, 0x02,               // id:2     -- 2 -- WHAT EVEN IS!?
+        0x00,                     // bool:1
 
-        test('skip void', function t(assert) {
-            var result = Health.rw.readFrom(new Buffer([
-                0x02,                     // type:1   -- 2 -- BOOL
-                0x00, 0x02,               // id:2     -- 2 -- WHAT EVEN IS!?
-                0x00,                     // bool:1
+        0x00                      // typeid:1 -- 0 -- STOP
+    ]), 0);
+    if (result.err) {
+        return assert.end(result.err);
+    }
+    assert.deepEqual(result.value, new Health());
+    assert.end();
+});
 
-                0x00                      // typeid:1 -- 0 -- STOP
-            ]), 0);
-            if (result.err) {
-                return assert.end(result.err);
-            }
-            assert.deepEqual(result.value, new Health());
-            assert.end();
-        });
+test('string', function t(assert) {
+    var result = Health.rw.readFrom(new Buffer([
+        11,                       // typeid:1 -- 11 -- STRING
+        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
+        0x00, 0x00, 0x00, 0x02,   // len~4
+        0x20, 0x20,               // '  '
+        0x00                      // typeid:1 -- 0  -- STOP
+    ]), 0);
+    if (result.err) {
+        return assert.end(result.err);
+    }
+    assert.deepEqual(result.value, new Health());
+    assert.end();
+});
 
-        test('string', function t(assert) {
-            var result = Health.rw.readFrom(new Buffer([
-                11,                       // typeid:1 -- 11 -- STRING
-                0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
-                0x00, 0x00, 0x00, 0x02,   // len~4
-                0x20, 0x20,               // '  '
-                0x00                      // typeid:1 -- 0  -- STOP
-            ]), 0);
-            if (result.err) {
-                return assert.end(result.err);
-            }
-            assert.deepEqual(result.value, new Health());
-            assert.end();
-        });
+test('struct', function t(assert) {
+    var result = Health.rw.readFrom(new Buffer([
+        12,                       // typeid:1 -- 12 -- STRUCT
+        0x00, 0x02,               // id:2     -- 2  -- ?
+        11,                       //   typeid:1 -- 11 -- STRING
+        0x00, 0x01,               //   fieldid:2 -- 1 -- ?
+        0x00, 0x00, 0x00, 0x02,   //   len~4
+        0x20, 0x20,               //   '  '
+        0x00,                     //   typeid:1 -- 0  -- STOP
+        0x00                      // typeid:1 -- 0  -- STOP
+    ]), 0);
+    if (result.err) {
+        return assert.end(result.err);
+    }
+    assert.deepEqual(result.value, new Health());
+    assert.end();
+});
 
-        test('struct', function t(assert) {
-            var result = Health.rw.readFrom(new Buffer([
-                12,                       // typeid:1 -- 12 -- STRUCT
-                0x00, 0x02,               // id:2     -- 2  -- ?
-                11,                       //   typeid:1 -- 11 -- STRING
-                0x00, 0x01,               //   fieldid:2 -- 1 -- ?
-                0x00, 0x00, 0x00, 0x02,   //   len~4
-                0x20, 0x20,               //   '  '
-                0x00,                     //   typeid:1 -- 0  -- STOP
-                0x00                      // typeid:1 -- 0  -- STOP
-            ]), 0);
-            if (result.err) {
-                return assert.end(result.err);
-            }
-            assert.deepEqual(result.value, new Health());
-            assert.end();
-        });
+test('map', function t(assert) {
+    var result = Health.rw.readFrom(new Buffer([
+        0x0d,                   // typeid:1           -- 13, map
+        0x00, 0x02,             // id:2               -- 2 UNKNOWN
 
-        test('map', function t(assert) {
-            var result = Health.rw.readFrom(new Buffer([
-                0x0d,                   // typeid:1           -- 13, map
-                0x00, 0x02,             // id:2               -- 2 UNKNOWN
+        // Thus begins a large map
+        0x0b,                   // key_type:1         -- string    @ 4
+        0x0c,                   // val_type:1         -- struct
+        0x00, 0x00, 0x00, 0x02, // length:4           -- 2
+                                //                    --
+        0x00, 0x00, 0x00, 0x04, // key[0] str_len:4   -- 4         @ 10
+        0x6b, 0x65, 0x79, 0x30, // key[0] chars       -- "key0"    @ 14
+        0x0c,                   // val[0] type:1      -- struct    @ 18
+        0x00, 0x01,             // val[0] id:2        -- 1         @ 19
+        0x08,                   // val[0] > type:1    -- i32       @ 21
+        0x00, 0x01,             // val[0] > id:2      -- 1         @ 22
+        0x00, 0x00, 0x00, 0x14, // val[0] > Int32BE   -- 20        @ 24
+        0x00,                   // val[0] > type:1    -- stop      @ 25
+        0x0c,                   // val[0] type:1      -- struct    @ 26
+        0x00, 0x02,             // val[0] id:2        -- 2         @ 27
+        0x0b,                   // val[0] > type:1    -- string    @ 29
+        0x00, 0x01,             // val[0] > id:2      -- 1         @ 30
+        0x00, 0x00, 0x00, 0x04, // val[0] > str_len:4 -- 4         @ 32
+        0x73, 0x74, 0x72, 0x32, // val[0] > chars     -- "str2"    @ 36
+        0x00,                   // val[0] > type:1    -- stop      @ 40
+        0x00,                   // val[0] > type:1    -- stop
+                                //                    --
+        0x00, 0x00, 0x00, 0x04, // key[1] str_len:4   -- 4
+        0x6b, 0x65, 0x79, 0x31, // key[1] chars       -- "key1"
+        0x0c,                   // val[1] type:1      -- struct
+        0x00, 0x01,             // val[1] id:2        -- 1
+        0x08,                   // val[1] > type:1    -- i32
+        0x00, 0x01,             // val[1] > id:2      -- 1
+        0x00, 0x00, 0x00, 0x0a, // val[1] > Int32BE   -- 10
+        0x00,                   // val[1] > type:1    -- stop
+        0x0c,                   // val[1] type:1      -- struct
+        0x00, 0x02,             // val[1] id:2        -- 2
+        0x0b,                   // val[1] > type:1    -- string
+        0x00, 0x01,             // val[1] > id:2      -- 1
+        0x00, 0x00, 0x00, 0x04, // val[1] > str_len:4 -- 4
+        0x73, 0x74, 0x72, 0x31, // val[1] > chars     -- "str1"
+        0x00,                   // val[1] > type:1    -- stop
+        0x00,                   // val[1] > type:1    -- stop
+        // Thus ends the map
 
-                // Thus begins a large map
-                0x0b,                   // key_type:1         -- string    @ 4
-                0x0c,                   // val_type:1         -- struct
-                0x00, 0x00, 0x00, 0x02, // length:4           -- 2
-                                        //                    --
-                0x00, 0x00, 0x00, 0x04, // key[0] str_len:4   -- 4         @ 10
-                0x6b, 0x65, 0x79, 0x30, // key[0] chars       -- "key0"    @ 14
-                0x0c,                   // val[0] type:1      -- struct    @ 18
-                0x00, 0x01,             // val[0] id:2        -- 1         @ 19
-                0x08,                   // val[0] > type:1    -- i32       @ 21
-                0x00, 0x01,             // val[0] > id:2      -- 1         @ 22
-                0x00, 0x00, 0x00, 0x14, // val[0] > Int32BE   -- 20        @ 24
-                0x00,                   // val[0] > type:1    -- stop      @ 25
-                0x0c,                   // val[0] type:1      -- struct    @ 26
-                0x00, 0x02,             // val[0] id:2        -- 2         @ 27
-                0x0b,                   // val[0] > type:1    -- string    @ 29
-                0x00, 0x01,             // val[0] > id:2      -- 1         @ 30
-                0x00, 0x00, 0x00, 0x04, // val[0] > str_len:4 -- 4         @ 32
-                0x73, 0x74, 0x72, 0x32, // val[0] > chars     -- "str2"    @ 36
-                0x00,                   // val[0] > type:1    -- stop      @ 40
-                0x00,                   // val[0] > type:1    -- stop
-                                        //                    --
-                0x00, 0x00, 0x00, 0x04, // key[1] str_len:4   -- 4
-                0x6b, 0x65, 0x79, 0x31, // key[1] chars       -- "key1"
-                0x0c,                   // val[1] type:1      -- struct
-                0x00, 0x01,             // val[1] id:2        -- 1
-                0x08,                   // val[1] > type:1    -- i32
-                0x00, 0x01,             // val[1] > id:2      -- 1
-                0x00, 0x00, 0x00, 0x0a, // val[1] > Int32BE   -- 10
-                0x00,                   // val[1] > type:1    -- stop
-                0x0c,                   // val[1] type:1      -- struct
-                0x00, 0x02,             // val[1] id:2        -- 2
-                0x0b,                   // val[1] > type:1    -- string
-                0x00, 0x01,             // val[1] > id:2      -- 1
-                0x00, 0x00, 0x00, 0x04, // val[1] > str_len:4 -- 4
-                0x73, 0x74, 0x72, 0x31, // val[1] > chars     -- "str1"
-                0x00,                   // val[1] > type:1    -- stop
-                0x00,                   // val[1] > type:1    -- stop
-                // Thus ends the map
+        0x00                      // typeid:1         -- 0 STOP
+    ]), 0);
+    if (result.err) {
+        return assert.end(result.err);
+    }
+    assert.deepEqual(result.value, new Health());
+    assert.end();
+});
 
-                0x00                      // typeid:1         -- 0 STOP
-            ]), 0);
-            if (result.err) {
-                return assert.end(result.err);
-            }
-            assert.deepEqual(result.value, new Health());
-            assert.end();
-        });
+test('list', function t(assert) {
+    var result = Health.rw.readFrom(new Buffer([
+        0x02,                     // type:1      -- 2 BOOL
+        0x00, 0x02,               // id:2        -- 2 UNKNOWN
+        0x0f,                     // typeid:1    -- 15, list
 
-        test('list', function t(assert) {
-            var result = Health.rw.readFrom(new Buffer([
-                0x02,                     // type:1      -- 2 BOOL
-                0x00, 0x02,               // id:2        -- 2 UNKNOWN
-                0x0f,                     // typeid:1    -- 15, list
+        // Thus begins a list
+        0x0c,                   // el_type:1     -- struct
+        0x00, 0x00, 0x00, 0x03, // length:4      -- 3
+        0x08,                   // el[0] type:1  -- i32
+        0x00, 0x01,             // el[0] id:2    -- 2
+        0x00, 0x00, 0x00, 0x1e, // el[0] Int32BE -- 30
+        0x00,                   // el[0] type:1  -- stop
+        0x08,                   // el[1] type:1  -- i32
+        0x00, 0x01,             // el[1] id:2    -- 2
+        0x00, 0x00, 0x00, 0x64, // el[1] Int32BE -- 100
+        0x00,                   // el[1] type:1  -- stop
+        0x08,                   // el[2] type:1  -- i32
+        0x00, 0x01,             // el[2] id:2    -- 2
+        0x00, 0x00, 0x00, 0xc8, // el[2] Int32BE -- 200
+        0x00,                   // el[2] type:1  -- stop
+        // Thus ends the map
 
-                // Thus begins a list
-                0x0c,                   // el_type:1     -- struct
-                0x00, 0x00, 0x00, 0x03, // length:4      -- 3
-                0x08,                   // el[0] type:1  -- i32
-                0x00, 0x01,             // el[0] id:2    -- 2
-                0x00, 0x00, 0x00, 0x1e, // el[0] Int32BE -- 30
-                0x00,                   // el[0] type:1  -- stop
-                0x08,                   // el[1] type:1  -- i32
-                0x00, 0x01,             // el[1] id:2    -- 2
-                0x00, 0x00, 0x00, 0x64, // el[1] Int32BE -- 100
-                0x00,                   // el[1] type:1  -- stop
-                0x08,                   // el[2] type:1  -- i32
-                0x00, 0x01,             // el[2] id:2    -- 2
-                0x00, 0x00, 0x00, 0xc8, // el[2] Int32BE -- 200
-                0x00,                   // el[2] type:1  -- stop
-                // Thus ends the map
-
-                0x00                      // typeid:1    -- 0 STOP
-            ]), 0);
-            if (result.err) {
-                return assert.end(result.err);
-            }
-            assert.deepEqual(result.value, new Health());
-            assert.end();
-        });
-    });
-
+        0x00                      // typeid:1    -- 0 STOP
+    ]), 0);
+    if (result.err) {
+        return assert.end(result.err);
+    }
+    assert.deepEqual(result.value, new Health());
+    assert.end();
 });

--- a/test/struct-skip.js
+++ b/test/struct-skip.js
@@ -20,15 +20,17 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var Buffer = require('buffer').Buffer;
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-
-    var Buffer = require('buffer').Buffer;
-    var fs = require('fs');
-    var path = require('path');
+withLoader(function (loadThrift, test) {
     var source = fs.readFileSync(path.join(__dirname, 'struct.thrift'), 'ascii');
     loadThrift({source: source}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
 
         var Health = thrift.$Health;
 
@@ -166,4 +168,5 @@ module.exports = function(loadThrift) {
             assert.end();
         });
     });
-}
+
+});

--- a/test/struct.js
+++ b/test/struct.js
@@ -22,375 +22,344 @@
 /* eslint max-len:[0, 120] */
 'use strict';
 
-/* eslint-disable max-statements */
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var Literal = require('../ast').Literal;
+var ThriftStruct = require('../struct').ThriftStruct;
+var ThriftBoolean = require('../boolean').ThriftBoolean;
+var Thrift = require('../thrift').Thrift;
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var Literal = require('../ast').Literal;
-    var ThriftStruct = require('../struct').ThriftStruct;
-    var ThriftBoolean = require('../boolean').ThriftBoolean;
-    var Thrift = require('../thrift').Thrift;
+var thriftHealth = new ThriftStruct();
 
-    var thriftHealth = new ThriftStruct();
+var undefinedDefault = new Literal(undefined);
+var nullDefault = new Literal(null);
 
-    var undefinedDefault = new Literal(undefined);
-    var nullDefault = new Literal(null);
+// Manually drive compile(idl) and link(thrift). This would be done by the Spec.
 
-    // Manually drive compile(idl) and link(thrift). This would be done by the Spec.
+var thriftMock = {
+    structs: {},
+    resolve: function resolve() {
+        // pretend all fields are boolean
+        return new ThriftBoolean();
+    },
+    resolveValue: function resolveValue() {
+    }
+};
 
-    var thriftMock = {
-        structs: {},
-        resolve: function resolve() {
-            // pretend all fields are boolean
-            return new ThriftBoolean();
-        },
-        resolveValue: function resolveValue() {
+thriftHealth.compile({
+    id: {name: 'Health'},
+    fields: [
+        {
+            id: {value: 1},
+            name: 'ok',
+            valueType: {
+                type: 'BaseType',
+                baseType: 'boolean'
+            },
+            optional: false,
+            required: true
         }
-    };
+    ]
+}, {});
 
-    thriftHealth.compile({
-        id: {name: 'Health'},
-        fields: [
-            {
-                id: {value: 1},
-                name: 'ok',
-                valueType: {
-                    type: 'BaseType',
-                    baseType: 'boolean'
-                },
-                optional: false,
-                required: true
-            }
-        ]
-    }, {});
+thriftHealth.link(thriftMock);
 
-    thriftHealth.link(thriftMock);
+var Health = thriftHealth.Constructor;
 
-    var Health = thriftHealth.Constructor;
+var cases = [
 
-    var cases = [
+    // good
+    [new Health({ok: true}), [
+        0x02,                      // type:1 -- 2 -- BOOL
+        0x00, 0x01,                // id:2   -- 1 -- ok
+        0x01,                      // ok:1   -- 1 -- true
+        0x00                       // type:1 -- 0 -- stop
+    ]],
 
-        // good
-        [new Health({ok: true}), [
-            0x02,                      // type:1 -- 2 -- BOOL
-            0x00, 0x01,                // id:2   -- 1 -- ok
-            0x01,                      // ok:1   -- 1 -- true
-            0x00                       // type:1 -- 0 -- stop
-        ]],
+    // bad
+    [new Health({ok: false}), [
+        0x02,                      // type:1 -- 2 -- BOOL
+        0x00, 0x01,                // id:2   -- 1 -- ok
+        0x00,                      // ok:1   -- 0 -- false
+        0x00                       // type:1 -- 0 -- stop
+    ]]
 
-        // bad
-        [new Health({ok: false}), [
-            0x02,                      // type:1 -- 2 -- BOOL
-            0x00, 0x01,                // id:2   -- 1 -- ok
-            0x00,                      // ok:1   -- 0 -- false
-            0x00                       // type:1 -- 0 -- stop
-        ]]
+];
 
-    ];
+test('HealthRW', testRW.cases(Health.rw, cases));
 
-    test('HealthRW', testRW.cases(Health.rw, cases));
+test('HealthRW to Buffer', function t(assert) {
+    var res = Health.rw.toBuffer(cases[0][0]);
+    assert.deepEqual(res.value, new Buffer(cases[0][1]), 'buffer matches');
+    assert.end();
+});
 
-    test('HealthRW to Buffer', function t(assert) {
-        var res = Health.rw.toBuffer(cases[0][0]);
-        assert.deepEqual(res.value, new Buffer(cases[0][1]), 'buffer matches');
-        assert.end();
-    });
+test('HealthRW from Buffer', function t(assert) {
+    var res = Health.rw.fromBuffer(new Buffer(cases[0][1]));
+    assert.deepEqual(res.value, cases[0][0], 'object matches');
+    assert.end();
+});
 
-    test('HealthRW from Buffer', function t(assert) {
-        var res = Health.rw.fromBuffer(new Buffer(cases[0][1]));
-        assert.deepEqual(res.value, cases[0][0], 'object matches');
-        assert.end();
-    });
+test('complains of missing required field', function t(assert) {
+    var res = Health.rw.readFrom(new Buffer([
+        0x00                      // typeid:1 -- 0 -- STOP
+    ]), 0);
+    assert.ok(res.err, 'required field error');
+    if (!res.err) return;
+    assert.equal(res.err.message, 'missing required field "ok" with id 1 on Health');
+    assert.end();
+});
 
-    test('complains of missing required field', function t(assert) {
-        var res = Health.rw.readFrom(new Buffer([
-            0x00                      // typeid:1 -- 0 -- STOP
-        ]), 0);
-        assert.ok(res.err, 'required field error');
-        if (!res.err) return;
-        assert.equal(res.err.message, 'missing required field "ok" with id 1 on Health');
-        assert.end();
-    });
+test('struct skips unknown void', function t(assert) {
+    var res = Health.rw.readFrom(new Buffer([
+        0x02,                     // type:1   -- 2 -- BOOL
+        0x00, 0x02,               // id:2     -- 2 -- WHAT EVEN IS!?
+        0x00,                     // bool:1
 
-    test('struct skips unknown void', function t(assert) {
-        var res = Health.rw.readFrom(new Buffer([
-            0x02,                     // type:1   -- 2 -- BOOL
-            0x00, 0x02,               // id:2     -- 2 -- WHAT EVEN IS!?
-            0x00,                     // bool:1
+        0x02,                     // type:1   -- 2 -- BOOL
+        0x00, 0x01,               // id:2     -- 1 -- ok
+        0x01,                     // ok:1     -- 1 -- true
 
-            0x02,                     // type:1   -- 2 -- BOOL
-            0x00, 0x01,               // id:2     -- 1 -- ok
-            0x01,                     // ok:1     -- 1 -- true
+        0x00                      // typeid:1 -- 0 -- STOP
+    ]), 0);
+    if (res.err) {
+        return assert.end(res.err);
+    }
+    assert.deepEqual(res.value, new Health({ok: true}));
+    assert.end();
+});
 
-            0x00                      // typeid:1 -- 0 -- STOP
-        ]), 0);
-        if (res.err) {
-            return assert.end(res.err);
-        }
-        assert.deepEqual(res.value, new Health({ok: true}));
-        assert.end();
-    });
+test('fails to read unexpected typeid for known field', function t(assert) {
+    var buffer = new Buffer([
+        0x01,       // typeid:1 -- 1 -- VOID
+        0x00, 0x01, // fid:2    -- 1 -- ok
+        0x00        // typeid:1 -- 0 -- STOP
+    ]);
+    var res = Health.rw.readFrom(buffer, 0);
+    if (!res.err) {
+        assert.fail('should be an error');
+        return assert.end();
+    }
+    assert.equal(res.err.message, 'unexpected typeid 1 (VOID) for field "ok" ' +
+        'with id 1 on Health; expected 2 (BOOL)');
+    assert.end();
+});
 
-    test('fails to read unexpected typeid for known field', function t(assert) {
-        var buffer = new Buffer([
-            0x01,       // typeid:1 -- 1 -- VOID
-            0x00, 0x01, // fid:2    -- 1 -- ok
-            0x00        // typeid:1 -- 0 -- STOP
-        ]);
-        var res = Health.rw.readFrom(buffer, 0);
-        if (!res.err) {
-            assert.fail('should be an error');
-            return assert.end();
-        }
-        assert.equal(res.err.message, 'unexpected typeid 1 (VOID) for field "ok" ' +
-            'with id 1 on Health; expected 2 (BOOL)');
-        assert.end();
-    });
+test('struct skips unknown string', function t(assert) {
+    var res = Health.rw.readFrom(new Buffer([
+        0x02,                     // type:1   -- 2 -- BOOL
+        0x00, 0x01,               // id:2     -- 1 -- ok
+        0x01,                     // ok:1     -- 1 -- true
 
-    test('struct skips unknown string', function t(assert) {
-        var res = Health.rw.readFrom(new Buffer([
-            0x02,                     // type:1   -- 2 -- BOOL
-            0x00, 0x01,               // id:2     -- 1 -- ok
-            0x01,                     // ok:1     -- 1 -- true
+        11,                       // typeid:1 -- 11 -- STRING
+        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
+        0x00, 0x00, 0x00, 0x02,   // len~4
+        0x20, 0x20,               // '  '
 
-            11,                       // typeid:1 -- 11 -- STRING
-            0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
-            0x00, 0x00, 0x00, 0x02,   // len~4
-            0x20, 0x20,               // '  '
+        0x00                      // typeid:1 -- 0  -- STOP
+    ]), 0);
+    if (res.err) {
+        return assert.end(res.err);
+    }
+    assert.deepEqual(res.value, new Health({ok: true}));
+    assert.end();
+});
 
-            0x00                      // typeid:1 -- 0  -- STOP
-        ]), 0);
-        if (res.err) {
-            return assert.end(res.err);
-        }
-        assert.deepEqual(res.value, new Health({ok: true}));
-        assert.end();
-    });
+test('struct skips unknown struct', function t(assert) {
+    var res = Health.rw.readFrom(new Buffer([
+        0x02,                     // type:1   -- 2 -- BOOL
+        0x00, 0x01,               // id:2     -- 1 -- ok
+        0x01,                     // ok:1     -- 1 -- true
 
-    test('struct skips unknown struct', function t(assert) {
-        var res = Health.rw.readFrom(new Buffer([
-            0x02,                     // type:1   -- 2 -- BOOL
-            0x00, 0x01,               // id:2     -- 1 -- ok
-            0x01,                     // ok:1     -- 1 -- true
+        0x0c,                     // typeid:1 -- 12 -- STRUCT
+        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
 
-            0x0c,                     // typeid:1 -- 12 -- STRUCT
-            0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
+        0x01,                     // typeid:1 -- 1  -- VOID
+        0x01,                     // typeid:1 -- 1  -- VOID
+        0x0b,                     // typeid:1 -- 11 -- STRING
+        0x00, 0x00, 0x00, 0x02,   // len~4
+        0x20, 0x20,               // '  '
+        0x01,                     // typeid:1 -- 1  -- VOID
+        0x00,                     // typeid:1 -- 0  -- STOP
 
-            0x01,                     // typeid:1 -- 1  -- VOID
-            0x01,                     // typeid:1 -- 1  -- VOID
-            0x0b,                     // typeid:1 -- 11 -- STRING
-            0x00, 0x00, 0x00, 0x02,   // len~4
-            0x20, 0x20,               // '  '
-            0x01,                     // typeid:1 -- 1  -- VOID
-            0x00,                     // typeid:1 -- 0  -- STOP
+        0x00                      // typeid:1 -- 0  -- STOP
+    ]), 0);
+    if (res.err) {
+        return assert.end(res.err);
+    }
+    assert.deepEqual(res.value, new Health({ok: true}));
+    assert.end();
+});
 
-            0x00                      // typeid:1 -- 0  -- STOP
-        ]), 0);
-        if (res.err) {
-            return assert.end(res.err);
-        }
-        assert.deepEqual(res.value, new Health({ok: true}));
-        assert.end();
-    });
+test('struct skips uknown map', function t(assert) {
+    var res = Health.rw.readFrom(new Buffer([
+        0x02,                     // type:1   -- 2 BOOL
+        0x00, 0x01,               // id:2     -- 1 ok
+        0x01,                     // ok:1     -- 1 true
 
-    test('struct skips uknown map', function t(assert) {
-        var res = Health.rw.readFrom(new Buffer([
-            0x02,                     // type:1   -- 2 BOOL
-            0x00, 0x01,               // id:2     -- 1 ok
-            0x01,                     // ok:1     -- 1 true
+        0x0d,                     // typeid:1 -- 13, map
+        0x00, 0x02,               // id:2     -- 2 UNKNOWN
 
-            0x0d,                     // typeid:1 -- 13, map
-            0x00, 0x02,               // id:2     -- 2 UNKNOWN
+        // Thus begins a large map
+        0x0b,                   // key_type:1         -- string    @ 4
+        0x0c,                   // val_type:1         -- struct
+        0x00, 0x00, 0x00, 0x02, // length:4           -- 2
+                                //                    --
+        0x00, 0x00, 0x00, 0x04, // key[0] str_len:4   -- 4         @ 10
+        0x6b, 0x65, 0x79, 0x30, // key[0] chars       -- "key0"    @ 14
+        0x0c,                   // val[0] type:1      -- struct    @ 18
+        0x00, 0x01,             // val[0] id:2        -- 1         @ 19
+        0x08,                   // val[0] > type:1    -- i32       @ 21
+        0x00, 0x01,             // val[0] > id:2      -- 1         @ 22
+        0x00, 0x00, 0x00, 0x14, // val[0] > Int32BE   -- 20        @ 24
+        0x00,                   // val[0] > type:1    -- stop      @ 25
+        0x0c,                   // val[0] type:1      -- struct    @ 26
+        0x00, 0x02,             // val[0] id:2        -- 2         @ 27
+        0x0b,                   // val[0] > type:1    -- string    @ 29
+        0x00, 0x01,             // val[0] > id:2      -- 1         @ 30
+        0x00, 0x00, 0x00, 0x04, // val[0] > str_len:4 -- 4         @ 32
+        0x73, 0x74, 0x72, 0x32, // val[0] > chars     -- "str2"    @ 36
+        0x00,                   // val[0] > type:1    -- stop      @ 40
+        0x00,                   // val[0] > type:1    -- stop
+                                //                    --
+        0x00, 0x00, 0x00, 0x04, // key[1] str_len:4   -- 4
+        0x6b, 0x65, 0x79, 0x31, // key[1] chars       -- "key1"
+        0x0c,                   // val[1] type:1      -- struct
+        0x00, 0x01,             // val[1] id:2        -- 1
+        0x08,                   // val[1] > type:1    -- i32
+        0x00, 0x01,             // val[1] > id:2      -- 1
+        0x00, 0x00, 0x00, 0x0a, // val[1] > Int32BE   -- 10
+        0x00,                   // val[1] > type:1    -- stop
+        0x0c,                   // val[1] type:1      -- struct
+        0x00, 0x02,             // val[1] id:2        -- 2
+        0x0b,                   // val[1] > type:1    -- string
+        0x00, 0x01,             // val[1] > id:2      -- 1
+        0x00, 0x00, 0x00, 0x04, // val[1] > str_len:4 -- 4
+        0x73, 0x74, 0x72, 0x31, // val[1] > chars     -- "str1"
+        0x00,                   // val[1] > type:1    -- stop
+        0x00,                   // val[1] > type:1    -- stop
+        // Thus ends the map
 
-            // Thus begins a large map
-            0x0b,                   // key_type:1         -- string    @ 4
-            0x0c,                   // val_type:1         -- struct
-            0x00, 0x00, 0x00, 0x02, // length:4           -- 2
-                                    //                    --
-            0x00, 0x00, 0x00, 0x04, // key[0] str_len:4   -- 4         @ 10
-            0x6b, 0x65, 0x79, 0x30, // key[0] chars       -- "key0"    @ 14
-            0x0c,                   // val[0] type:1      -- struct    @ 18
-            0x00, 0x01,             // val[0] id:2        -- 1         @ 19
-            0x08,                   // val[0] > type:1    -- i32       @ 21
-            0x00, 0x01,             // val[0] > id:2      -- 1         @ 22
-            0x00, 0x00, 0x00, 0x14, // val[0] > Int32BE   -- 20        @ 24
-            0x00,                   // val[0] > type:1    -- stop      @ 25
-            0x0c,                   // val[0] type:1      -- struct    @ 26
-            0x00, 0x02,             // val[0] id:2        -- 2         @ 27
-            0x0b,                   // val[0] > type:1    -- string    @ 29
-            0x00, 0x01,             // val[0] > id:2      -- 1         @ 30
-            0x00, 0x00, 0x00, 0x04, // val[0] > str_len:4 -- 4         @ 32
-            0x73, 0x74, 0x72, 0x32, // val[0] > chars     -- "str2"    @ 36
-            0x00,                   // val[0] > type:1    -- stop      @ 40
-            0x00,                   // val[0] > type:1    -- stop
-                                    //                    --
-            0x00, 0x00, 0x00, 0x04, // key[1] str_len:4   -- 4
-            0x6b, 0x65, 0x79, 0x31, // key[1] chars       -- "key1"
-            0x0c,                   // val[1] type:1      -- struct
-            0x00, 0x01,             // val[1] id:2        -- 1
-            0x08,                   // val[1] > type:1    -- i32
-            0x00, 0x01,             // val[1] > id:2      -- 1
-            0x00, 0x00, 0x00, 0x0a, // val[1] > Int32BE   -- 10
-            0x00,                   // val[1] > type:1    -- stop
-            0x0c,                   // val[1] type:1      -- struct
-            0x00, 0x02,             // val[1] id:2        -- 2
-            0x0b,                   // val[1] > type:1    -- string
-            0x00, 0x01,             // val[1] > id:2      -- 1
-            0x00, 0x00, 0x00, 0x04, // val[1] > str_len:4 -- 4
-            0x73, 0x74, 0x72, 0x31, // val[1] > chars     -- "str1"
-            0x00,                   // val[1] > type:1    -- stop
-            0x00,                   // val[1] > type:1    -- stop
-            // Thus ends the map
+        0x00                      // typeid:1         -- 0 STOP
+    ]), 0);
+    if (res.err) {
+        return assert.end(res.err);
+    }
+    assert.deepEqual(res.value, new Health({ok: true}));
+    assert.end();
+});
 
-            0x00                      // typeid:1         -- 0 STOP
-        ]), 0);
-        if (res.err) {
-            return assert.end(res.err);
-        }
-        assert.deepEqual(res.value, new Health({ok: true}));
-        assert.end();
-    });
+test('struct skips unknown list', function t(assert) {
+    var res = Health.rw.readFrom(new Buffer([
+        0x02,                     // type:1   -- 2 BOOL
+        0x00, 0x01,               // id:2     -- 1 ok
+        0x00,                     // ok:1     -- 0 false
 
-    test('struct skips unknown list', function t(assert) {
-        var res = Health.rw.readFrom(new Buffer([
-            0x02,                     // type:1   -- 2 BOOL
-            0x00, 0x01,               // id:2     -- 1 ok
-            0x00,                     // ok:1     -- 0 false
+        0x0f,                     // typeid:1    -- 15, list
+        0x00, 0x02,               // id:2        -- 2 UNKNOWN
 
-            0x0f,                     // typeid:1    -- 15, list
-            0x00, 0x02,               // id:2        -- 2 UNKNOWN
+        // Thus begins a list
+        0x0c,                   // el_type:1     -- struct
+        0x00, 0x00, 0x00, 0x03, // length:4      -- 3
+        0x08,                   // el[0] type:1  -- i32
+        0x00, 0x01,             // el[0] id:2    -- 2
+        0x00, 0x00, 0x00, 0x1e, // el[0] Int32BE -- 30
+        0x00,                   // el[0] type:1  -- stop
+        0x08,                   // el[1] type:1  -- i32
+        0x00, 0x01,             // el[1] id:2    -- 2
+        0x00, 0x00, 0x00, 0x64, // el[1] Int32BE -- 100
+        0x00,                   // el[1] type:1  -- stop
+        0x08,                   // el[2] type:1  -- i32
+        0x00, 0x01,             // el[2] id:2    -- 2
+        0x00, 0x00, 0x00, 0xc8, // el[2] Int32BE -- 200
+        0x00,                   // el[2] type:1  -- stop
+        // Thus ends the map
 
-            // Thus begins a list
-            0x0c,                   // el_type:1     -- struct
-            0x00, 0x00, 0x00, 0x03, // length:4      -- 3
-            0x08,                   // el[0] type:1  -- i32
-            0x00, 0x01,             // el[0] id:2    -- 2
-            0x00, 0x00, 0x00, 0x1e, // el[0] Int32BE -- 30
-            0x00,                   // el[0] type:1  -- stop
-            0x08,                   // el[1] type:1  -- i32
-            0x00, 0x01,             // el[1] id:2    -- 2
-            0x00, 0x00, 0x00, 0x64, // el[1] Int32BE -- 100
-            0x00,                   // el[1] type:1  -- stop
-            0x08,                   // el[2] type:1  -- i32
-            0x00, 0x01,             // el[2] id:2    -- 2
-            0x00, 0x00, 0x00, 0xc8, // el[2] Int32BE -- 200
-            0x00,                   // el[2] type:1  -- stop
-            // Thus ends the map
+        0x00                      // typeid:1    -- 0 STOP
+    ]), 0);
+    if (res.err) {
+        return assert.end(res.err);
+    }
+    assert.deepEqual(res.value, new Health({ok: false}));
+    assert.end();
+});
 
-            0x00                      // typeid:1    -- 0 STOP
-        ]), 0);
-        if (res.err) {
-            return assert.end(res.err);
-        }
-        assert.deepEqual(res.value, new Health({ok: false}));
-        assert.end();
-    });
-
-    test('every field must be marked in strict mode', function t(assert) {
-        var thrift = new ThriftStruct();
-        try {
-            thrift.compile({
-                id: {name: 'Health'},
-                fields: [
-                    {
-                        id: {value: 1},
-                        name: 'ok',
-                        valueType: {
-                            type: 'BaseType',
-                            baseType: 'boolean'
-                        },
-                        optional: false,
-                        required: false
-                    }
-                ]
-            });
-            thrift.link(thriftMock);
-            assert.fail('should throw');
-        } catch (err) {
-            assert.equal(err.message, 'every field must be marked optional, ' +
-                'required, or have a default value on Health including "ok" in strict mode');
-        }
-        assert.end();
-    });
-
-    test('structs and fields must be possible to rename with a js.name annotation', function t(assert) {
-        var thrift = new ThriftStruct({strict: false});
+test('every field must be marked in strict mode', function t(assert) {
+    var thrift = new ThriftStruct();
+    try {
         thrift.compile({
-            id: {name: 'given'},
-            annotations: {'js.name': 'alt'},
+            id: {name: 'Health'},
             fields: [
                 {
                     id: {value: 1},
-                    name: 'given',
-                    annotations: {'js.name': 'alt'},
+                    name: 'ok',
                     valueType: {
                         type: 'BaseType',
-                        baseType: 'i32'
-                    }
+                        baseType: 'boolean'
+                    },
+                    optional: false,
+                    required: false
                 }
             ]
         });
-        assert.equal(thrift.name, 'alt', 'struct must have alternate js.name');
-        assert.equal(thrift.fieldsById[1].name, 'alt', 'field must have alternate js.name');
-        assert.end();
-    });
+        thrift.link(thriftMock);
+        assert.fail('should throw');
+    } catch (err) {
+        assert.equal(err.message, 'every field must be marked optional, ' +
+            'required, or have a default value on Health including "ok" in strict mode');
+    }
+    assert.end();
+});
 
-    test('required fields are required on measuring byte length', function t(assert) {
-        var health = new Health();
-        var res = Health.rw.byteLength(health);
-        if (!res.err) {
-            assert.fail('should fail to assess byte length');
-            return assert.end();
-        }
-        assert.equal(res.err.message, 'missing required field "ok" with id 1 on Health', 'message checks out');
-        assert.deepEqual(res.err.what, health, 'err.what should be the input struct');
-        assert.end();
+test('structs and fields must be possible to rename with a js.name annotation', function t(assert) {
+    var thrift = new ThriftStruct({strict: false});
+    thrift.compile({
+        id: {name: 'given'},
+        annotations: {'js.name': 'alt'},
+        fields: [
+            {
+                id: {value: 1},
+                name: 'given',
+                annotations: {'js.name': 'alt'},
+                valueType: {
+                    type: 'BaseType',
+                    baseType: 'i32'
+                }
+            }
+        ]
     });
+    assert.equal(thrift.name, 'alt', 'struct must have alternate js.name');
+    assert.equal(thrift.fieldsById[1].name, 'alt', 'field must have alternate js.name');
+    assert.end();
+});
 
-    test('required fields are required on writing into buffer', function t(assert) {
-        var health = new Health();
-        var res = Health.rw.writeInto(health, new Buffer(100), 0);
-        if (!res.err) {
-            assert.fail('should fail to write');
-            return assert.end();
-        }
-        assert.equal(res.err.message, 'missing required field "ok" with id 1 on Health', 'message checks out');
-        assert.deepEqual(res.err.what, health, 'err.what should be the input struct');
-        assert.end();
-    });
+test('required fields are required on measuring byte length', function t(assert) {
+    var health = new Health();
+    var res = Health.rw.byteLength(health);
+    if (!res.err) {
+        assert.fail('should fail to assess byte length');
+        return assert.end();
+    }
+    assert.equal(res.err.message, 'missing required field "ok" with id 1 on Health', 'message checks out');
+    assert.deepEqual(res.err.what, health, 'err.what should be the input struct');
+    assert.end();
+});
 
-    test('arguments must not be marked optional', function t(assert) {
-        var argStruct = new ThriftStruct({strict: false});
-        try {
-            argStruct.compile({
-                id: {name: 'foo_args'},
-                isArgument: true,
-                fields: [
-                    {
-                        id: {value: 1},
-                        name: 'name',
-                        valueType: {
-                            type: 'BaseType',
-                            baseType: 'i64'
-                        },
-                        required: false,
-                        optional: true
-                    }
-                ]
-            }, {});
-            argStruct.link(thriftMock);
-            assert.fail('should fail to write');
-        } catch (err) {
-            assert.equal(err.message, 'no field of an argument struct may be ' +
-                'marked optional including name of foo_args; ' +
-                'consider new Thrift({allowOptionalArguments: true}).');
-        }
-        assert.end();
-    });
+test('required fields are required on writing into buffer', function t(assert) {
+    var health = new Health();
+    var res = Health.rw.writeInto(health, new Buffer(100), 0);
+    if (!res.err) {
+        assert.fail('should fail to write');
+        return assert.end();
+    }
+    assert.equal(res.err.message, 'missing required field "ok" with id 1 on Health', 'message checks out');
+    assert.deepEqual(res.err.what, health, 'err.what should be the input struct');
+    assert.end();
+});
 
-    test('arguments may now be marked optional', function t(assert) {
-        var argStruct = new ThriftStruct({strict: false});
+test('arguments must not be marked optional', function t(assert) {
+    var argStruct = new ThriftStruct({strict: false});
+    try {
         argStruct.compile({
             id: {name: 'foo_args'},
             isArgument: true,
@@ -406,41 +375,135 @@ module.exports = function(loadThrift) {
                     optional: true
                 }
             ]
-        }, {allowOptionalArguments: true});
+        }, {});
         argStruct.link(thriftMock);
-        assert.end();
-    });
+        assert.fail('should fail to write');
+    } catch (err) {
+        assert.equal(err.message, 'no field of an argument struct may be ' +
+            'marked optional including name of foo_args; ' +
+            'consider new Thrift({allowOptionalArguments: true}).');
+    }
+    assert.end();
+});
 
-    test('arguments are now optional by default', function t(assert) {
-        var argStruct = new ThriftStruct({strict: false});
-        argStruct.compile({
-            id: {name: 'foo_args'},
-            isArgument: true,
-            fields: [
-                {
-                    id: {value: 1},
-                    name: 'name',
-                    valueType: {
-                        type: 'BaseType',
-                        baseType: 'i64'
-                    },
-                    required: false,
-                    optional: false
-                }
-            ]
-        }, {allowOptionalArguments: true});
-        argStruct.link(thriftMock);
-        assert.ok(argStruct.fieldsByName.name.optional, 'argument field defaults to optional');
-        assert.end();
-    });
+test('arguments may now be marked optional', function t(assert) {
+    var argStruct = new ThriftStruct({strict: false});
+    argStruct.compile({
+        id: {name: 'foo_args'},
+        isArgument: true,
+        fields: [
+            {
+                id: {value: 1},
+                name: 'name',
+                valueType: {
+                    type: 'BaseType',
+                    baseType: 'i64'
+                },
+                required: false,
+                optional: true
+            }
+        ]
+    }, {allowOptionalArguments: true});
+    argStruct.link(thriftMock);
+    assert.end();
+});
 
-    test('skips optional elided arguments', function t(assert) {
-        var thrift = new ThriftStruct();
+test('arguments are now optional by default', function t(assert) {
+    var argStruct = new ThriftStruct({strict: false});
+    argStruct.compile({
+        id: {name: 'foo_args'},
+        isArgument: true,
+        fields: [
+            {
+                id: {value: 1},
+                name: 'name',
+                valueType: {
+                    type: 'BaseType',
+                    baseType: 'i64'
+                },
+                required: false,
+                optional: false
+            }
+        ]
+    }, {allowOptionalArguments: true});
+    argStruct.link(thriftMock);
+    assert.ok(argStruct.fieldsByName.name.optional, 'argument field defaults to optional');
+    assert.end();
+});
+
+test('skips optional elided arguments', function t(assert) {
+    var thrift = new ThriftStruct();
+    thrift.compile({
+        id: {name: 'Health'},
+        fields: [
+            {
+                id: {value: 1},
+                name: 'ok',
+                valueType: {
+                    type: 'BaseType',
+                    baseType: 'boolean'
+                },
+                optional: true,
+                required: false
+            }
+        ]
+    }, {});
+    thrift.link(thriftMock);
+    var health = new thrift.Constructor();
+
+    var byteLengthRes = thrift.rw.byteLength(health);
+    if (byteLengthRes.err) return assert.end(byteLengthRes.err);
+    assert.equal(byteLengthRes.length, 1, 'only needs one byte');
+
+    var buffer = new Buffer(byteLengthRes.length);
+    var writeRes = thrift.rw.writeInto(health, buffer, 0);
+    if (writeRes.err) return assert.end(writeRes.err);
+    assert.equal(writeRes.offset, 1, 'writes to end of buffer');
+    assert.deepEqual(buffer, new Buffer([0x00]), 'writes stop byte only');
+
+    assert.end();
+});
+
+test('skips optional elided struct (all fields optional)', function t(assert) {
+    var thrift = new ThriftStruct();
+    thrift.compile({
+        id: {name: 'Health'},
+        fields: [
+            {
+                id: {value: 1},
+                name: 'ok',
+                valueType: {
+                    type: 'BaseType',
+                    baseType: 'boolean'
+                },
+                optional: true,
+                required: false
+            }
+        ]
+    }, {});
+    thrift.link(thriftMock);
+
+    var byteLengthRes = thrift.rw.byteLength(null);
+    if (byteLengthRes.err) return assert.end(byteLengthRes.err);
+    assert.equal(byteLengthRes.length, 1, 'only needs one byte');
+
+    var buffer = new Buffer(byteLengthRes.length);
+    var writeRes = thrift.rw.writeInto(null, buffer, 0);
+    if (writeRes.err) return assert.end(writeRes.err);
+    assert.equal(writeRes.offset, 1, 'writes to end of buffer');
+    assert.deepEqual(buffer, new Buffer([0x00]), 'writes stop byte only');
+
+    assert.end();
+});
+
+test('enforces ordinal identifiers', function t(assert) {
+    var thrift = new ThriftStruct();
+    try {
         thrift.compile({
             id: {name: 'Health'},
             fields: [
                 {
-                    id: {value: 1},
+                    id: {value: 0, line: 1, column: 4},
                     name: 'ok',
                     valueType: {
                         type: 'BaseType',
@@ -451,145 +514,77 @@ module.exports = function(loadThrift) {
                 }
             ]
         }, {});
-        thrift.link(thriftMock);
-        var health = new thrift.Constructor();
+        assert.fail('should throw');
+    } catch (err) {
+        assert.equal(err.message, 'field identifier must be greater than 0 for "ok" on "Health" at 1:4');
+    }
+    assert.end();
+});
 
-        var byteLengthRes = thrift.rw.byteLength(health);
-        if (byteLengthRes.err) return assert.end(byteLengthRes.err);
-        assert.equal(byteLengthRes.length, 1, 'only needs one byte');
-
-        var buffer = new Buffer(byteLengthRes.length);
-        var writeRes = thrift.rw.writeInto(health, buffer, 0);
-        if (writeRes.err) return assert.end(writeRes.err);
-        assert.equal(writeRes.offset, 1, 'writes to end of buffer');
-        assert.deepEqual(buffer, new Buffer([0x00]), 'writes stop byte only');
-
-        assert.end();
-    });
-
-    test('skips optional elided struct (all fields optional)', function t(assert) {
-        var thrift = new ThriftStruct();
-        thrift.compile({
-            id: {name: 'Health'},
-            fields: [
-                {
-                    id: {value: 1},
-                    name: 'ok',
-                    valueType: {
-                        type: 'BaseType',
-                        baseType: 'boolean'
-                    },
-                    optional: true,
-                    required: false
-                }
-            ]
-        }, {});
-        thrift.link(thriftMock);
-
-        var byteLengthRes = thrift.rw.byteLength(null);
-        if (byteLengthRes.err) return assert.end(byteLengthRes.err);
-        assert.equal(byteLengthRes.length, 1, 'only needs one byte');
-
-        var buffer = new Buffer(byteLengthRes.length);
-        var writeRes = thrift.rw.writeInto(null, buffer, 0);
-        if (writeRes.err) return assert.end(writeRes.err);
-        assert.equal(writeRes.offset, 1, 'writes to end of buffer');
-        assert.deepEqual(buffer, new Buffer([0x00]), 'writes stop byte only');
-
-        assert.end();
-    });
-
-    test('enforces ordinal identifiers', function t(assert) {
-        var thrift = new ThriftStruct();
-        try {
-            thrift.compile({
-                id: {name: 'Health'},
-                fields: [
-                    {
-                        id: {value: 0, line: 1, column: 4},
-                        name: 'ok',
-                        valueType: {
-                            type: 'BaseType',
-                            baseType: 'boolean'
-                        },
-                        optional: true,
-                        required: false
-                    }
-                ]
-            }, {});
-            assert.fail('should throw');
-        } catch (err) {
-            assert.equal(err.message, 'field identifier must be greater than 0 for "ok" on "Health" at 1:4');
+test('allows undefined as default', function t(assert) {
+    var defaultStruct = new ThriftStruct({strict: false, defaultValueDefinition: undefinedDefault});
+    var tMock = {
+        structs: {},
+        resolve: function resolve() {
+            return new ThriftBoolean();
+        },
+        resolveValue: function resolveValue(valueDef) {
+            assert.equal(valueDef.type, 'Literal', 'Value definition is a literal');
+            assert.true(valueDef.hasOwnProperty('value'), 'Has defined value property');
+            assert.true(valueDef.value === undefined, 'Value is undefined');
+            return Thrift.prototype.resolveValue(valueDef);
         }
-        assert.end();
-    });
-
-    test('allows undefined as default', function t(assert) {
-        var defaultStruct = new ThriftStruct({strict: false, defaultValueDefinition: undefinedDefault});
-        var tMock = {
-            structs: {},
-            resolve: function resolve() {
-                return new ThriftBoolean();
-            },
-            resolveValue: function resolveValue(valueDef) {
-                assert.equal(valueDef.type, 'Literal', 'Value definition is a literal');
-                assert.true(valueDef.hasOwnProperty('value'), 'Has defined value property');
-                assert.true(valueDef.value === undefined, 'Value is undefined');
-                return Thrift.prototype.resolveValue(valueDef);
+    };
+    defaultStruct.compile({
+        id: {name: 'NewDefault'},
+        fields: [
+            {
+                id: {value: 1},
+                name: 'testDefault',
+                valueType: {
+                    type: 'BaseType',
+                    baseType: 'boolean'
+                },
+                required: false,
+                optional: false
             }
-        };
-        defaultStruct.compile({
-            id: {name: 'NewDefault'},
-            fields: [
-                {
-                    id: {value: 1},
-                    name: 'testDefault',
-                    valueType: {
-                        type: 'BaseType',
-                        baseType: 'boolean'
-                    },
-                    required: false,
-                    optional: false
-                }
-            ]
-        }, {allowOptionalArguments: true});
-        defaultStruct.link(tMock);
-        assert.true(defaultStruct.fieldsByName.testDefault.defaultValue === undefined, 'Default value is undefined');
-        assert.end();
-    });
+        ]
+    }, {allowOptionalArguments: true});
+    defaultStruct.link(tMock);
+    assert.true(defaultStruct.fieldsByName.testDefault.defaultValue === undefined, 'Default value is undefined');
+    assert.end();
+});
 
-    test('defaults to null as default value', function t(assert) {
-        var defaultStruct = new ThriftStruct({strict: false, defaultValueDefinition: nullDefault});
-        var tMock = {
-            structs: {},
-            resolve: function resolve() {
-                return new ThriftBoolean();
-            },
-            resolveValue: function resolveValue(valueDef) {
-                assert.equal(valueDef.type, 'Literal', 'Value definition is a literal');
-                assert.true(valueDef.hasOwnProperty('value'), 'Has defined value property');
-                assert.true(valueDef.value === null, 'Value is null');
-                return Thrift.prototype.resolveValue(valueDef);
+test('defaults to null as default value', function t(assert) {
+    var defaultStruct = new ThriftStruct({strict: false, defaultValueDefinition: nullDefault});
+    var tMock = {
+        structs: {},
+        resolve: function resolve() {
+            return new ThriftBoolean();
+        },
+        resolveValue: function resolveValue(valueDef) {
+            assert.equal(valueDef.type, 'Literal', 'Value definition is a literal');
+            assert.true(valueDef.hasOwnProperty('value'), 'Has defined value property');
+            assert.true(valueDef.value === null, 'Value is null');
+            return Thrift.prototype.resolveValue(valueDef);
+        }
+    };
+    defaultStruct.compile({
+        id: {name: 'NewDefault'},
+        fields: [
+            {
+                id: {value: 1},
+                name: 'testDefault',
+                valueType: {
+                    type: 'BaseType',
+                    baseType: 'boolean'
+                },
+                required: false,
+                optional: false
             }
-        };
-        defaultStruct.compile({
-            id: {name: 'NewDefault'},
-            fields: [
-                {
-                    id: {value: 1},
-                    name: 'testDefault',
-                    valueType: {
-                        type: 'BaseType',
-                        baseType: 'boolean'
-                    },
-                    required: false,
-                    optional: false
-                }
-            ]
-        }, {allowOptionalArguments: true});
-        defaultStruct.link(tMock);
-        assert.true(defaultStruct.fieldsByName.testDefault.defaultValue === null, 'Default value value is null');
-        assert.end();
-    });
-}
-/* eslint-enable max-statements */
+        ]
+    }, {allowOptionalArguments: true});
+    defaultStruct.link(tMock);
+    assert.true(defaultStruct.fieldsByName.testDefault.defaultValue === null, 'Default value value is null');
+    assert.end();
+});

--- a/test/thrift-idl.js
+++ b/test/thrift-idl.js
@@ -21,40 +21,37 @@
 /* eslint max-len:[0, 120] */
 'use strict';
 
-module.exports = function(loadThrift) {
+var idl = require('../thrift-idl');
+var fs = require('fs');
+var path = require('path');
+var test = require('tape');
 
-    var idl = require('../thrift-idl');
-    var fs = require('fs');
-    var path = require('path');
-    var test = require('tape');
-
-    test('thrift IDL parser can parse thrift test files', function t(assert) {
-        var idls = {};
-        if (process.browser) {
-            idls = global.idls;
-        } else {
-            var extension = '.thrift';
-            var dirname = path.join(__dirname, 'thrift');
-            var filenames = fs.readdirSync(dirname);
-            for (var index = 0; index < filenames.length; index++) {
-                var filename = filenames[index];
-                var fullFilename = path.join(dirname, filename);
-                if (filename.indexOf(extension, filename.length - extension.length) > 0) {
-                    idls[filename] = fs.readFileSync(fullFilename, 'ascii');
-                }
+test('thrift IDL parser can parse thrift test files', function t(assert) {
+    var idls = {};
+    if (process.browser) {
+        idls = global.idls;
+    } else {
+        var extension = '.thrift';
+        var dirname = path.join(__dirname, 'thrift');
+        var filenames = fs.readdirSync(dirname);
+        for (var index = 0; index < filenames.length; index++) {
+            var filename = filenames[index];
+            var fullFilename = path.join(dirname, filename);
+            if (filename.indexOf(extension, filename.length - extension.length) > 0) {
+                idls[filename] = fs.readFileSync(fullFilename, 'ascii');
             }
         }
+    }
 
-        var filenames = Object.keys(idls);
-        for (var i = 0; i < filenames.length; i++) {
-            var file = filenames[i];
-            try {
-                idl.parse(idls[file]);
-                assert.pass(file);
-            } catch (err) {
-                assert.fail(file);
-            }
+    var filenames = Object.keys(idls);
+    for (var i = 0; i < filenames.length; i++) {
+        var file = filenames[i];
+        try {
+            idl.parse(idls[file]);
+            assert.pass(file);
+        } catch (err) {
+            assert.fail(file);
         }
-        assert.end();
-    });
-}
+    }
+    assert.end();
+});

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -22,12 +22,12 @@
 /* eslint-disable max-len */
 'use strict';
 
-var Thrift = require('../thrift').Thrift;
-var withLoader = require('./loader');
-
 var fs = require('fs');
 var path = require('path');
 var test = require('tape');
+var Thrift = require('../thrift').Thrift;
+
+var thrift;
 
 var allowFilesystemAccess = !process.browser;
 var idls;
@@ -35,352 +35,252 @@ if (process.browser) {
     idls = global.idls;
 }
 
-withLoader(function (loadThrift, test) {
-
-    test('thrift must be passed options', function t(assert) {
-        loadThrift(null, function (err, thrift) {
-            assert.throws(
-                function throws() { throw err; },
-                /options required/,
-                'throws on missing options'
-            );
-            assert.end();
-        });
-    });
-
-    test('thrift options must be an object', function t(assert) {
-        loadThrift('not-an-object', function (err, thrift) {
-            assert.throws(
-                function throws() { throw err; },
-                /options must be object/,
-                'throws on options not an object'
-            );
-            assert.end();
-        });
-    });
-
-    test('Thrift.load: options.fs.readFile required', function t(assert) {
-        assert.throws(
-            function throws() {
-                Thrift.load({}, function (err, thrift) {
-                });
-            },
-            /options.fs.readFile is required for async loading/,
-            'throws when calling Thrift.load without options.fs.readFile'
-        );
-        assert.end();
-    });
-
-    test('thrift expects the source to be a string', function t(assert) {
-        loadThrift({source: 42}, function (err, thrift) {
-            assert.throws(
-                function throws() { throw err; },
-                /source must be string/,
-                'throws when source is not a string'
-            );
-            assert.end();
-        });
-    });
-
-    test('thrift parses from source', function t(assert) {
-        var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
-        loadThrift({source: source}, function (err, thrift) {
-            assert.ifError(err);
-            assert.equal(
-                thrift.getSources().entryPoint,
-                'service.thrift',
-                'Correct default entryPoint value when no includes'
-            );
-            assert.pass('thrift parses');
-            assert.end();
-        });
-    });
-
-    test('thrift parses from entryPoint', function t(assert) {
-        var filename = path.join(__dirname, 'thrift.thrift');
-        loadThrift({
-            entryPoint: filename,
-            allowFilesystemAccess: allowFilesystemAccess,
-            idls: idls
-        }, function (err, thrift) {
-            assert.ifError(err);
-            assert.equal(
-                thrift.getSources().entryPoint,
-                'thrift.thrift',
-                'Correct default entryPoint value when no includes'
-            );
-            assert.pass('thrift parses');
-            assert.end();
-        });
-    });
-
-    test('thrift parses from idls', function t(assert) {
-        var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
-        loadThrift({idls: {'service.thrift': source}, entryPoint: 'service.thrift'}, function (err, thrift) {
-            assert.ifError(err);
-            assert.equal(
-                thrift.getSources().entryPoint,
-                'service.thrift',
-                'Correct default entryPoint value when no includes'
-            );
-            assert.pass('thrift parses');
-            assert.end();
-        });
-    })
-
+test('thrift parses from source', function t(assert) {
     var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
-    loadThrift({source: source}, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
+    thrift = new Thrift({source: source});
+    assert.equal(
+        thrift.getSources().entryPoint,
+        'service.thrift',
+        'Correct default entryPoint value when no includes'
+    );
+    assert.pass('thrift parses');
+    assert.end();
+});
 
-        test('can get type result from thrift', function t(assert) {
-            var res = thrift.getTypeResult('Struct');
-            if (res.err) return assert.end(res.err);
-            assert.ok(res.value, 'got struct');
-            assert.end();
-        });
-
-        test('can get type from thrift', function t(assert) {
-            var Struct = thrift.getType('Struct');
-            assert.ok(Struct, 'got struct');
-            assert.end();
-        });
-
-        test('can read struct from buffer', function t(assert) {
-            var struct = thrift.Struct.fromBuffer(new Buffer([
-                0x08, // typeid:1 -- 8, i32
-                0x00, 0x01, // id:2 -- 1, "number"
-                0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
-                0x00 // typeid:1 -- 0, stop
-            ]));
-            assert.ok(struct instanceof thrift.Struct, 'struct instanceof Strict');
-            assert.deepEqual(struct, new thrift.Struct({number: 10}), 'struct properties read properly');
-            assert.end();
-        });
-
-        test('can read struct result from buffer', function t(assert) {
-            var result = thrift.Struct.fromBufferResult(new Buffer([
-                0x08, // typeid:1 -- 8, i32
-                0x00, 0x01, // id:2 -- 1, "number"
-                0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
-                0x00 // typeid:1 -- 0, stop
-            ]));
-            assert.ok(result.value instanceof thrift.Struct, 'struct instanceof Strict');
-            assert.deepEqual(result.value, new thrift.Struct({number: 10}), 'struct properties read properly');
-            assert.end();
-        });
-
-        test('can write struct to buffer', function t(assert) {
-            var buffer = thrift.Struct.toBuffer(new thrift.Struct({number: 10}));
-            assert.deepEqual(buffer, new Buffer([
-                0x08, // typeid:1 -- 8, i32
-                0x00, 0x01, // id:2 -- 1, "number"
-                0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
-                0x00 // typeid:1 -- 0, stop
-            ]));
-            assert.end();
-        });
-
-        test('can write struct to buffer', function t(assert) {
-            var result = thrift.Struct.toBufferResult(new thrift.Struct({number: 10}));
-            assert.deepEqual(result.value, new Buffer([
-                0x08, // typeid:1 -- 8, i32
-                0x00, 0x01, // id:2 -- 1, "number"
-                0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
-                0x00 // typeid:1 -- 0, stop
-            ]));
-            assert.end();
-        });
-
-        test('can get type error result from thrift', function t(assert) {
-            var res = thrift.getTypeResult('Bogus');
-            assert.ok(res.err, 'got error');
-            if (!res.err) return assert.end();
-            assert.equal(res.err.message, 'type Bogus not found. Make sure that the service name matches a service in the thrift file and that the method name is nested under that service.');
-            assert.end();
-        });
-
-        test('can get type error from thrift', function t(assert) {
-            assert.throws(
-                function throws() { thrift.getType('Bogus'); },
-                /type Bogus not found. Make sure that the service name matches a service in the thrift file and that the method name is nested under that service./,
-                'getType fails when type not found'
-            );
-            assert.end();
-        });
+test('thrift parses from entryPoint', function t(assert) {
+    var filename = path.join(__dirname, 'thrift.thrift');
+    thrift = new Thrift({
+        entryPoint: filename,
+        allowFilesystemAccess: allowFilesystemAccess,
+        idls: idls
     });
+    assert.equal(
+        thrift.getSources().entryPoint,
+        'thrift.thrift',
+        'Correct default entryPoint value when no includes'
+    );
+    assert.pass('thrift parses');
+    assert.end();
+});
 
-    test('reference error in thrift', function t(assert) {
-        var source = fs.readFileSync(path.join(__dirname, 'reference-error.thrift'), 'ascii');
-        loadThrift({source: source}, function (err, thrift) {
-            assert.throws(
-                function throws() { throw err; },
-                /cannot resolve reference to Struct at 3:19/,
-                'Thrift fails with a struct reference error'
-            );
-            assert.end();
+test('thrift parses from idls', function t(assert) {
+    var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
+    thrift = new Thrift({idls: {'service.thrift': source}, entryPoint: 'service.thrift'});
+    assert.equal(
+        thrift.getSources().entryPoint,
+        'service.thrift',
+        'Correct default entryPoint value when no includes'
+    );
+    assert.pass('thrift parses');
+    assert.end();
+})
+
+test('can get type result from thrift', function t(assert) {
+    var res = thrift.getTypeResult('Struct');
+    if (res.err) return assert.end(res.err);
+    assert.ok(res.value, 'got struct');
+    assert.end();
+});
+
+test('can get type from thrift', function t(assert) {
+    var Struct = thrift.getType('Struct');
+    assert.ok(Struct, 'got struct');
+    assert.end();
+});
+
+test('can read struct from buffer', function t(assert) {
+    var struct = thrift.Struct.fromBuffer(new Buffer([
+        0x08, // typeid:1 -- 8, i32
+        0x00, 0x01, // id:2 -- 1, "number"
+        0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
+        0x00 // typeid:1 -- 0, stop
+    ]));
+    assert.ok(struct instanceof thrift.Struct, 'struct instanceof Strict');
+    assert.deepEqual(struct, new thrift.Struct({number: 10}), 'struct properties read properly');
+    assert.end();
+});
+
+test('can read struct result from buffer', function t(assert) {
+    var result = thrift.Struct.fromBufferResult(new Buffer([
+        0x08, // typeid:1 -- 8, i32
+        0x00, 0x01, // id:2 -- 1, "number"
+        0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
+        0x00 // typeid:1 -- 0, stop
+    ]));
+    assert.ok(result.value instanceof thrift.Struct, 'struct instanceof Strict');
+    assert.deepEqual(result.value, new thrift.Struct({number: 10}), 'struct properties read properly');
+    assert.end();
+});
+
+test('can write struct to buffer', function t(assert) {
+    var buffer = thrift.Struct.toBuffer(new thrift.Struct({number: 10}));
+    assert.deepEqual(buffer, new Buffer([
+        0x08, // typeid:1 -- 8, i32
+        0x00, 0x01, // id:2 -- 1, "number"
+        0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
+        0x00 // typeid:1 -- 0, stop
+    ]));
+    assert.end();
+});
+
+test('can write struct to buffer', function t(assert) {
+    var result = thrift.Struct.toBufferResult(new thrift.Struct({number: 10}));
+    assert.deepEqual(result.value, new Buffer([
+        0x08, // typeid:1 -- 8, i32
+        0x00, 0x01, // id:2 -- 1, "number"
+        0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
+        0x00 // typeid:1 -- 0, stop
+    ]));
+    assert.end();
+});
+
+test('can get type error result from thrift', function t(assert) {
+    var res = thrift.getTypeResult('Bogus');
+    assert.ok(res.err, 'got error');
+    if (!res.err) return assert.end();
+    assert.equal(res.err.message, 'type Bogus not found. Make sure that the service name matches a service in the thrift file and that the method name is nested under that service.');
+    assert.end();
+});
+
+test('can get type error from thrift', function t(assert) {
+    try {
+        thrift.getType('Bogus');
+        assert.fail('error expected');
+    } catch (err) {
+        assert.equal(err.message, 'type Bogus not found. Make sure that the service name matches a service in the thrift file and that the method name is nested under that service.');
+    }
+    assert.end();
+});
+
+test('reference error in thrift', function t(assert) {
+    var source = fs.readFileSync(path.join(__dirname, 'reference-error.thrift'), 'ascii');
+    try {
+        thrift = new Thrift({source: source});
+        assert.fail('thrift should not parse');
+    } catch (err) {
+        assert.equal(err.message, 'cannot resolve reference to Struct at 3:19');
+    }
+    assert.end();
+});
+
+test('duplicate reference in thrift', function t(assert) {
+    var source = fs.readFileSync(path.join(__dirname, 'duplicate-error.thrift'), 'ascii');
+    try {
+        thrift = new Thrift({source: source});
+        assert.fail('thrift should not parse');
+    } catch (err) {
+        assert.equal(err.message, 'duplicate reference to Service at 4:9');
+    }
+    assert.end();
+});
+
+test('get endpoints single service', function t(assert) {
+    if (process.browser) {
+        thrift = new Thrift({source: fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii')});
+    } else {
+        thrift = new Thrift({entryPoint: path.join(__dirname, 'thrift.thrift'), allowFilesystemAccess: true});
+    }
+    assert.deepEqual(
+        thrift.getServiceEndpoints(),
+        ['Service::foo'],
+        'Correct endpoints from single service'
+    );
+    assert.end();
+});
+
+test('get endpoints multi service', function t(assert) {
+    if (process.browser) {
+        thrift = new Thrift({source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii')});
+    } else {
+        thrift = new Thrift({
+            entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
+            allowFilesystemAccess: true
         });
-    });
+    }
+    assert.deepEqual(
+        thrift.getServiceEndpoints(),
+        ['Weatherwax::headology', 'Weatherwax::wossname', 'Ogg::voodoo'],
+        'Correct endpoints from multiple services'
+    );
+    assert.end();
+});
 
-    test('duplicate reference in thrift', function t(assert) {
-        var source = fs.readFileSync(path.join(__dirname, 'duplicate-error.thrift'), 'ascii');
-        loadThrift({source: source}, function (err, thrift) {
-            assert.throws(
-                function throws() { throw err; },
-                /duplicate reference to Service at 4:9/,
-                'Thrift fails with a double service reference'
-            );
-            assert.end();
+test('respects default as undefined', function t(assert) {
+    if (process.browser) {
+        thrift = new Thrift({
+            source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii'),
+            defaultAsUndefined: true
         });
-    });
-
-    test('get endpoints single service', function t(assert) {
-        var opts;
-        if (process.browser) {
-            opts = {
-                source: fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii')
-            };
-        } else {
-            opts = {
-                entryPoint: path.join(__dirname, 'thrift.thrift'),
-                allowFilesystemAccess: true
-            };
-        }
-        loadThrift(opts, function (err, thrift) {
-            assert.ifError(err);
-            assert.deepEqual(
-                thrift.getServiceEndpoints(),
-                ['Service::foo'],
-                'Correct endpoints from single service'
-            );
-            assert.end();
+    } else {
+        thrift = new Thrift({
+            entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
+            allowFilesystemAccess: true,
+            defaultAsUndefined: true
         });
-    });
+    }
+    var valueDefinition = thrift.defaultValueDefinition;
+    assert.true(
+        valueDefinition.type === 'Literal',
+        'Correct value definition type'
+    );
+    assert.true(
+        valueDefinition.value === undefined,
+        'Correct value definition value'
+    );
+    assert.end();
+});
 
-    test('get endpoints multi service', function t(assert) {
-        var opts;
-        if (process.browser) {
-            opts = {
-                source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii')
-            };
-        } else {
-            opts = {
-                entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
-                allowFilesystemAccess: true
-            };
-        }
-        loadThrift(opts, function (err, thrift) {
-            assert.ifError(err);
-            assert.deepEqual(
-                thrift.getServiceEndpoints(),
-                ['Weatherwax::headology', 'Weatherwax::wossname', 'Ogg::voodoo'],
-                'Correct endpoints from multiple services'
-            );
-            assert.end();
+test('defaults to null default value', function t(assert) {
+    if (process.browser) {
+        thrift = new Thrift({source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii')});
+    } else {
+        thrift = new Thrift({
+            entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
+            allowFilesystemAccess: true
         });
-    });
+    }
+    var valueDefinition = thrift.defaultValueDefinition;
+    assert.true(
+        valueDefinition.type === 'Literal',
+        'Correct value definition type'
+    );
+    assert.true(
+        valueDefinition.value === null,
+        'Correct value definition value'
+    );
+    assert.end();
+});
 
-    test('respects default as undefined', function t(assert) {
-        var opts;
-        if (process.browser) {
-            opts = {
-                source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii'),
-                defaultAsUndefined: true
-            };
-        } else {
-            opts = {
-                entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
-                allowFilesystemAccess: true,
-                defaultAsUndefined: true
-            };
-        }
-        loadThrift(opts, function (err, thrift) {
-            assert.ifError(err);
-            var valueDefinition = thrift.defaultValueDefinition;
-            assert.true(
-                valueDefinition.type === 'Literal',
-                'Correct value definition type'
-            );
-            assert.true(
-                valueDefinition.value === undefined,
-                'Correct value definition value'
-            );
-            assert.end();
+test('get endpoints multi service target', function t(assert) {
+    if (process.browser) {
+        thrift = new Thrift({source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii')});
+    } else {
+        thrift = new Thrift({
+            entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
+            allowFilesystemAccess: true
         });
-    });
+    }
+    assert.deepEqual(
+        thrift.getServiceEndpoints('Ogg'),
+        ['Ogg::voodoo'],
+        'Correct endpoints from multiple services'
+    );
+    assert.end();
+});
 
-    test('defaults to null default value', function t(assert) {
-        var opts;
-        if (process.browser) {
-            opts = {
-                source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii')
-            };
-        } else {
-            opts = {
-                entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
-                allowFilesystemAccess: true
-            };
-        }
-        loadThrift(opts, function (err, thrift) {
-            assert.ifError(err);
-            var valueDefinition = thrift.defaultValueDefinition;
-            assert.true(
-                valueDefinition.type === 'Literal',
-                'Correct value definition type'
-            );
-            assert.true(
-                valueDefinition.value === null,
-                'Correct value definition value'
-            );
-            assert.end();
+test('get endpoints multi service bad target', function t(assert) {
+    if (process.browser) {
+        thrift = new Thrift({source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii')});
+    } else {
+        thrift = new Thrift({
+            entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
+            allowFilesystemAccess: true
         });
-    });
-
-    test('get endpoints multi service target', function t(assert) {
-        var opts;
-        if (process.browser) {
-            opts = {
-                source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii')
-            };
-        } else {
-            opts = {
-                entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
-                allowFilesystemAccess: true
-            };
-        }
-        loadThrift(opts, function (err, thrift) {
-            assert.ifError(err);
-            assert.deepEqual(
-                thrift.getServiceEndpoints('Ogg'),
-                ['Ogg::voodoo'],
-                'Correct endpoints from multiple services'
-            );
-            assert.end();
-        });
-    });
-
-    test('get endpoints multi service bad target', function t(assert) {
-        var opts;
-        if (process.browser) {
-            opts = {
-                source: fs.readFileSync(path.join(__dirname, 'thrift', 'MultiService.thrift'), 'ascii')
-            };
-        } else {
-            opts = {
-                entryPoint: path.join(__dirname, 'thrift', 'MultiService.thrift'),
-                allowFilesystemAccess: true
-            };
-        }
-        loadThrift(opts, function (err, thrift) {
-            assert.ifError(err);
-            assert.deepEqual(
-                thrift.getServiceEndpoints('Magrat'),
-                [],
-                'Correct empty endpoints list'
-            );
-            assert.end();
-        });
-    });
-
+    }
+    assert.deepEqual(
+        thrift.getServiceEndpoints('Magrat'),
+        [],
+        'Correct empty endpoints list'
+    );
+    assert.end();
 });

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -22,17 +22,20 @@
 /* eslint-disable max-len */
 'use strict';
 
-module.exports = function(loadThrift) {
+var Thrift = require('../thrift').Thrift;
+var withLoader = require('./loader');
 
-    var fs = require('fs');
-    var path = require('path');
-    var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var test = require('tape');
 
-    var allowFilesystemAccess = !process.browser;
-    var idls;
-    if (process.browser) {
-        idls = global.idls;
-    }
+var allowFilesystemAccess = !process.browser;
+var idls;
+if (process.browser) {
+    idls = global.idls;
+}
+
+withLoader(function (loadThrift, test) {
 
     test('thrift must be passed options', function t(assert) {
         loadThrift(null, function (err, thrift) {
@@ -56,16 +59,16 @@ module.exports = function(loadThrift) {
         });
     });
 
-    test('Thrift.load : options.fs.readFile required', function t(assert) {
-        var Thrift = require('../thrift').Thrift;
-        Thrift.load({}, function (err, thrift) {
-            assert.throws(
-                function throws() { throw err; },
-                /options.fs.readFile required/,
-                'throws when calling Thrift.load without options.fs.readFile'
-            );
-            assert.end();
-        });
+    test('Thrift.load: options.fs.readFile required', function t(assert) {
+        assert.throws(
+            function throws() {
+                Thrift.load({}, function (err, thrift) {
+                });
+            },
+            /options.fs.readFile is required for async loading/,
+            'throws when calling Thrift.load without options.fs.readFile'
+        );
+        assert.end();
     });
 
     test('thrift expects the source to be a string', function t(assert) {
@@ -82,6 +85,7 @@ module.exports = function(loadThrift) {
     test('thrift parses from source', function t(assert) {
         var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
         loadThrift({source: source}, function (err, thrift) {
+            assert.ifError(err);
             assert.equal(
                 thrift.getSources().entryPoint,
                 'service.thrift',
@@ -99,6 +103,7 @@ module.exports = function(loadThrift) {
             allowFilesystemAccess: allowFilesystemAccess,
             idls: idls
         }, function (err, thrift) {
+            assert.ifError(err);
             assert.equal(
                 thrift.getSources().entryPoint,
                 'thrift.thrift',
@@ -112,6 +117,7 @@ module.exports = function(loadThrift) {
     test('thrift parses from idls', function t(assert) {
         var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
         loadThrift({idls: {'service.thrift': source}, entryPoint: 'service.thrift'}, function (err, thrift) {
+            assert.ifError(err);
             assert.equal(
                 thrift.getSources().entryPoint,
                 'service.thrift',
@@ -124,6 +130,9 @@ module.exports = function(loadThrift) {
 
     var source = fs.readFileSync(path.join(__dirname, 'thrift.thrift'), 'ascii');
     loadThrift({source: source}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
 
         test('can get type result from thrift', function t(assert) {
             var res = thrift.getTypeResult('Struct');
@@ -239,6 +248,7 @@ module.exports = function(loadThrift) {
             };
         }
         loadThrift(opts, function (err, thrift) {
+            assert.ifError(err);
             assert.deepEqual(
                 thrift.getServiceEndpoints(),
                 ['Service::foo'],
@@ -261,6 +271,7 @@ module.exports = function(loadThrift) {
             };
         }
         loadThrift(opts, function (err, thrift) {
+            assert.ifError(err);
             assert.deepEqual(
                 thrift.getServiceEndpoints(),
                 ['Weatherwax::headology', 'Weatherwax::wossname', 'Ogg::voodoo'],
@@ -285,6 +296,7 @@ module.exports = function(loadThrift) {
             };
         }
         loadThrift(opts, function (err, thrift) {
+            assert.ifError(err);
             var valueDefinition = thrift.defaultValueDefinition;
             assert.true(
                 valueDefinition.type === 'Literal',
@@ -311,6 +323,7 @@ module.exports = function(loadThrift) {
             };
         }
         loadThrift(opts, function (err, thrift) {
+            assert.ifError(err);
             var valueDefinition = thrift.defaultValueDefinition;
             assert.true(
                 valueDefinition.type === 'Literal',
@@ -337,6 +350,7 @@ module.exports = function(loadThrift) {
             };
         }
         loadThrift(opts, function (err, thrift) {
+            assert.ifError(err);
             assert.deepEqual(
                 thrift.getServiceEndpoints('Ogg'),
                 ['Ogg::voodoo'],
@@ -359,6 +373,7 @@ module.exports = function(loadThrift) {
             };
         }
         loadThrift(opts, function (err, thrift) {
+            assert.ifError(err);
             assert.deepEqual(
                 thrift.getServiceEndpoints('Magrat'),
                 [],
@@ -367,4 +382,5 @@ module.exports = function(loadThrift) {
             assert.end();
         });
     });
-}
+
+});

--- a/test/tlist.js
+++ b/test/tlist.js
@@ -20,110 +20,107 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
+var thriftrw = require('../index');
+var TStruct = thriftrw.TStruct;
+var TListRW = thriftrw.TListRW;
+var TList = thriftrw.TList;
+var TField = thriftrw.TField;
 
-    var thriftrw = require('../index');
-    var TStruct = thriftrw.TStruct;
-    var TListRW = thriftrw.TListRW;
-    var TList = thriftrw.TList;
-    var TField = thriftrw.TField;
+test('TListRW', testRW.cases(TListRW, [
 
-    test('TListRW', testRW.cases(TListRW, [
+    [TList(12, [
+        TStruct([TField(8, 1, 30)]),
+        TStruct([TField(8, 1, 100)]),
+        TStruct([TField(8, 1, 200)])
+    ]), [
+        0x0c,                   // el_type:1          -- struct
+        0x00, 0x00, 0x00, 0x03, // length:4           -- 3
+        0x08,                   // el[0] type:1       -- i32
+        0x00, 0x01,             // el[0] id:2         -- 2
+        0x00, 0x00, 0x00, 0x1e, // el[0] Int32BE      -- 30
+        0x00,                   // el[0] type:1       -- stop
+        0x08,                   // el[1] type:1       -- i32
+        0x00, 0x01,             // el[1] id:2         -- 2
+        0x00, 0x00, 0x00, 0x64, // el[1] Int32BE      -- 100
+        0x00,                   // el[1] type:1       -- stop
+        0x08,                   // el[2] type:1       -- i32
+        0x00, 0x01,             // el[2] id:2         -- 2
+        0x00, 0x00, 0x00, 0xc8, // el[2] Int32BE      -- 200
+        0x00                    // el[2] type:1       -- stop
+    ]],
 
-        [TList(12, [
-            TStruct([TField(8, 1, 30)]),
-            TStruct([TField(8, 1, 100)]),
-            TStruct([TField(8, 1, 200)])
-        ]), [
-            0x0c,                   // el_type:1          -- struct
-            0x00, 0x00, 0x00, 0x03, // length:4           -- 3
-            0x08,                   // el[0] type:1       -- i32
-            0x00, 0x01,             // el[0] id:2         -- 2
-            0x00, 0x00, 0x00, 0x1e, // el[0] Int32BE      -- 30
-            0x00,                   // el[0] type:1       -- stop
-            0x08,                   // el[1] type:1       -- i32
-            0x00, 0x01,             // el[1] id:2         -- 2
-            0x00, 0x00, 0x00, 0x64, // el[1] Int32BE      -- 100
-            0x00,                   // el[1] type:1       -- stop
-            0x08,                   // el[2] type:1       -- i32
-            0x00, 0x01,             // el[2] id:2         -- 2
-            0x00, 0x00, 0x00, 0xc8, // el[2] Int32BE      -- 200
-            0x00                    // el[2] type:1       -- stop
-        ]],
+    [TList(15, [
+        TList(12, []),
+        TList(12, []),
+        TList(12, []),
+        TList(12, []),
+        TList(12, [])
+    ]), [
+        0x0f,                   // 3     | el_type:1       -- list
+        0x00, 0x00, 0x00, 0x05, // 3-6   | length:4        -- 5
+        0x0c,                   // 8     | el[0] el_type:1 -- STRUCT
+        0x00, 0x00, 0x00, 0x00, // 9-12  | el[0] length:4  -- 0
+        0x0c,                   // 13    | el[1] el_type:1 -- STRUCT
+        0x00, 0x00, 0x00, 0x00, // 14-17 | el[1] length:4  -- 0
+        0x0c,                   // .     | el[2] el_type:1 -- STRUCT
+        0x00, 0x00, 0x00, 0x00, // .     | el[2] length:4  -- 0
+        0x0c,                   // .     | el[3] el_type:1 -- STRUCT
+        0x00, 0x00, 0x00, 0x00, //       | el[3] length:4  -- 0
+        0x0c,                   //       | el[4] el_type:1 -- STRUCT
+        0x00, 0x00, 0x00, 0x00, //       | el[4] length:4  -- 0
+    ]],
 
-        [TList(15, [
-            TList(12, []),
-            TList(12, []),
-            TList(12, []),
-            TList(12, []),
-            TList(12, [])
-        ]), [
-            0x0f,                   // 3     | el_type:1       -- list
-            0x00, 0x00, 0x00, 0x05, // 3-6   | length:4        -- 5
-            0x0c,                   // 8     | el[0] el_type:1 -- STRUCT
-            0x00, 0x00, 0x00, 0x00, // 9-12  | el[0] length:4  -- 0
-            0x0c,                   // 13    | el[1] el_type:1 -- STRUCT
-            0x00, 0x00, 0x00, 0x00, // 14-17 | el[1] length:4  -- 0
-            0x0c,                   // .     | el[2] el_type:1 -- STRUCT
-            0x00, 0x00, 0x00, 0x00, // .     | el[2] length:4  -- 0
-            0x0c,                   // .     | el[3] el_type:1 -- STRUCT
-            0x00, 0x00, 0x00, 0x00, //       | el[3] length:4  -- 0
-            0x0c,                   //       | el[4] el_type:1 -- STRUCT
-            0x00, 0x00, 0x00, 0x00, //       | el[4] length:4  -- 0
-        ]],
-
-        {
-            readTest: {
-                bytes: [
-                    0x08,                  // el_type:1 -- i32
-                    0x80, 0x00, 0x00, 0x00 // length:4  -- 0
-                ],
-                error: {
-                    type: 'thrift-invalid-size',
-                    name: 'ThriftInvalidSizeError',
-                    message: 'invalid size -2147483648 of list::size; ' +
-                             'expects non-negative number',
-                    size: -2147483648,
-                    what: 'list::size'
-                }
-            }
-        },
-
-        {
-            lengthTest: {
-                value: TList(-1, []),
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of list::etype; ' +
-                             'expects one of the values in TYPE'
-                }
-            },
-            writeTest: {
-                value: TList(-1, []),
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of list::etype; ' +
-                             'expects one of the values in TYPE'
-                }
-            },
-            readTest: {
-                bytes: [
-                    0xff,                  // el_type:1 -- invalid (-1)
-                    0x00, 0x00, 0x00, 0x00 // length:4  -- 0
-                ],
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of list::etype; ' +
-                             'expects one of the values in TYPE'
-                }
+    {
+        readTest: {
+            bytes: [
+                0x08,                  // el_type:1 -- i32
+                0x80, 0x00, 0x00, 0x00 // length:4  -- 0
+            ],
+            error: {
+                type: 'thrift-invalid-size',
+                name: 'ThriftInvalidSizeError',
+                message: 'invalid size -2147483648 of list::size; ' +
+                         'expects non-negative number',
+                size: -2147483648,
+                what: 'list::size'
             }
         }
+    },
 
-    ]));
-}
+    {
+        lengthTest: {
+            value: TList(-1, []),
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of list::etype; ' +
+                         'expects one of the values in TYPE'
+            }
+        },
+        writeTest: {
+            value: TList(-1, []),
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of list::etype; ' +
+                         'expects one of the values in TYPE'
+            }
+        },
+        readTest: {
+            bytes: [
+                0xff,                  // el_type:1 -- invalid (-1)
+                0x00, 0x00, 0x00, 0x00 // length:4  -- 0
+            ],
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of list::etype; ' +
+                         'expects one of the values in TYPE'
+            }
+        }
+    }
+
+]));

--- a/test/tmap.js
+++ b/test/tmap.js
@@ -20,159 +20,156 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var Buffer = require('buffer').Buffer;
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
 
-    var Buffer = require('buffer').Buffer;
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
+var thriftrw = require('../index');
+var TStruct = thriftrw.TStruct;
+var TMap = thriftrw.TMap;
+var TMapRW = thriftrw.TMapRW;
+var TField = thriftrw.TField;
+var TPair = thriftrw.TPair;
 
-    var thriftrw = require('../index');
-    var TStruct = thriftrw.TStruct;
-    var TMap = thriftrw.TMap;
-    var TMapRW = thriftrw.TMapRW;
-    var TField = thriftrw.TField;
-    var TPair = thriftrw.TPair;
+test('TMapRW', testRW.cases(TMapRW, [
 
-    test('TMapRW', testRW.cases(TMapRW, [
+    [TMap(11, 12, [
+        TPair(Buffer('key0'), TStruct([
+            TField(12, 1, TStruct([TField(8, 1, 20)])),
+            TField(12, 2, TStruct([TField(11, 1, Buffer('str2'))]))
+        ])),
+        TPair(Buffer('key1'), TStruct([
+            TField(12, 1, TStruct([TField(8, 1, 10)])),
+            TField(12, 2, TStruct([TField(11, 1, Buffer('str1'))]))
+        ]))
+    ]), [
 
-        [TMap(11, 12, [
-            TPair(Buffer('key0'), TStruct([
-                TField(12, 1, TStruct([TField(8, 1, 20)])),
-                TField(12, 2, TStruct([TField(11, 1, Buffer('str2'))]))
-            ])),
-            TPair(Buffer('key1'), TStruct([
-                TField(12, 1, TStruct([TField(8, 1, 10)])),
-                TField(12, 2, TStruct([TField(11, 1, Buffer('str1'))]))
-            ]))
-        ]), [
+        0x0b,                   // key_type:1         -- string
+        0x0c,                   // val_type:1         -- struct
+        0x00, 0x00, 0x00, 0x02, // length:4           -- 2
+                                //                    --
+        0x00, 0x00, 0x00, 0x04, // key[0] str_len:4   -- 4
+        0x6b, 0x65, 0x79, 0x30, // key[0] chars       -- "key0"
+        0x0c,                   // val[0] type:1      -- struct
+        0x00, 0x01,             // val[0] id:2        -- 1
+        0x08,                   // val[0] > type:1    -- i32
+        0x00, 0x01,             // val[0] > id:2      -- 1
+        0x00, 0x00, 0x00, 0x14, // val[0] > Int32BE   -- 20
+        0x00,                   // val[0] > type:1    -- stop
+        0x0c,                   // val[0] type:1      -- struct
+        0x00, 0x02,             // val[0] id:2        -- 2
+        0x0b,                   // val[0] > type:1    -- string
+        0x00, 0x01,             // val[0] > id:2      -- 1
+        0x00, 0x00, 0x00, 0x04, // val[0] > str_len:4 -- 4
+        0x73, 0x74, 0x72, 0x32, // val[0] > chars     -- "str2"
+        0x00,                   // val[0] > type:1    -- stop
+        0x00,                   // val[0] > type:1    -- stop
+                                //                    --
+        0x00, 0x00, 0x00, 0x04, // key[1] str_len:4   -- 4
+        0x6b, 0x65, 0x79, 0x31, // key[1] chars       -- "key1"
+        0x0c,                   // val[1] type:1      -- struct
+        0x00, 0x01,             // val[1] id:2        -- 1
+        0x08,                   // val[1] > type:1    -- i32
+        0x00, 0x01,             // val[1] > id:2      -- 1
+        0x00, 0x00, 0x00, 0x0a, // val[1] > Int32BE   -- 10
+        0x00,                   // val[1] > type:1    -- stop
+        0x0c,                   // val[1] type:1      -- struct
+        0x00, 0x02,             // val[1] id:2        -- 2
+        0x0b,                   // val[1] > type:1    -- string
+        0x00, 0x01,             // val[1] > id:2      -- 1
+        0x00, 0x00, 0x00, 0x04, // val[1] > str_len:4 -- 4
+        0x73, 0x74, 0x72, 0x31, // val[1] > chars     -- "str1"
+        0x00,                   // val[1] > type:1    -- stop
+        0x00                    // val[1] > type:1    -- stop
+    ]],
 
-            0x0b,                   // key_type:1         -- string
-            0x0c,                   // val_type:1         -- struct
-            0x00, 0x00, 0x00, 0x02, // length:4           -- 2
-                                    //                    --
-            0x00, 0x00, 0x00, 0x04, // key[0] str_len:4   -- 4
-            0x6b, 0x65, 0x79, 0x30, // key[0] chars       -- "key0"
-            0x0c,                   // val[0] type:1      -- struct
-            0x00, 0x01,             // val[0] id:2        -- 1
-            0x08,                   // val[0] > type:1    -- i32
-            0x00, 0x01,             // val[0] > id:2      -- 1
-            0x00, 0x00, 0x00, 0x14, // val[0] > Int32BE   -- 20
-            0x00,                   // val[0] > type:1    -- stop
-            0x0c,                   // val[0] type:1      -- struct
-            0x00, 0x02,             // val[0] id:2        -- 2
-            0x0b,                   // val[0] > type:1    -- string
-            0x00, 0x01,             // val[0] > id:2      -- 1
-            0x00, 0x00, 0x00, 0x04, // val[0] > str_len:4 -- 4
-            0x73, 0x74, 0x72, 0x32, // val[0] > chars     -- "str2"
-            0x00,                   // val[0] > type:1    -- stop
-            0x00,                   // val[0] > type:1    -- stop
-                                    //                    --
-            0x00, 0x00, 0x00, 0x04, // key[1] str_len:4   -- 4
-            0x6b, 0x65, 0x79, 0x31, // key[1] chars       -- "key1"
-            0x0c,                   // val[1] type:1      -- struct
-            0x00, 0x01,             // val[1] id:2        -- 1
-            0x08,                   // val[1] > type:1    -- i32
-            0x00, 0x01,             // val[1] > id:2      -- 1
-            0x00, 0x00, 0x00, 0x0a, // val[1] > Int32BE   -- 10
-            0x00,                   // val[1] > type:1    -- stop
-            0x0c,                   // val[1] type:1      -- struct
-            0x00, 0x02,             // val[1] id:2        -- 2
-            0x0b,                   // val[1] > type:1    -- string
-            0x00, 0x01,             // val[1] > id:2      -- 1
-            0x00, 0x00, 0x00, 0x04, // val[1] > str_len:4 -- 4
-            0x73, 0x74, 0x72, 0x31, // val[1] > chars     -- "str1"
-            0x00,                   // val[1] > type:1    -- stop
-            0x00                    // val[1] > type:1    -- stop
-        ]],
-
-        // invalid size
-        {
-            readTest: {
-                bytes: [
-                    0x08,                  // key_type:1 -- i32
-                    0x08,                  // val_type:1 -- i32
-                    0x80, 0x00, 0x00, 0x00 // length:4   -- 0
-                ],
-                error: {
-                    type: 'thrift-invalid-size',
-                    name: 'ThriftInvalidSizeError',
-                    message: 'invalid size -2147483648 of map::size; ' +
-                             'expects non-negative number',
-                    size: -2147483648,
-                    what: 'map::size'
-                }
-            }
-        },
-
-        // invalid key type
-        {
-            lengthTest: {
-                value: TMap(-1, 8, []),
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of map::ktype; ' +
-                             'expects one of the values in TYPE'
-                }
-            },
-            writeTest: {
-                value: TMap(-1, 8, []),
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of map::ktype; ' +
-                             'expects one of the values in TYPE'
-                }
-            },
-            readTest: {
-                bytes: [
-                    0xff,                  // key_type:1 -- invalid (-1)
-                    0x08,                  // val_type:1 -- invalid (-1)
-                    0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-                ],
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of map::ktype; ' +
-                             'expects one of the values in TYPE'
-                }
-            }
-        },
-
-        // invalid val type
-        {
-            lengthTest: {
-                value: TMap(8, -1, []),
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of map::vtype; ' +
-                             'expects one of the values in TYPE'
-                }
-            },
-            writeTest: {
-                value: TMap(8, -1, []),
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of map::vtype; ' +
-                             'expects one of the values in TYPE'
-                }
-            },
-            readTest: {
-                bytes: [
-                    0x08,                  // key_type:1 -- invalid (-1)
-                    0xff,                  // val_type:1 -- invalid (-1)
-                    0x00, 0x00, 0x00, 0x00 // length:4   -- 0
-                ],
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of map::vtype; ' +
-                             'expects one of the values in TYPE'
-                }
+    // invalid size
+    {
+        readTest: {
+            bytes: [
+                0x08,                  // key_type:1 -- i32
+                0x08,                  // val_type:1 -- i32
+                0x80, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-invalid-size',
+                name: 'ThriftInvalidSizeError',
+                message: 'invalid size -2147483648 of map::size; ' +
+                         'expects non-negative number',
+                size: -2147483648,
+                what: 'map::size'
             }
         }
+    },
 
-    ]));
-}
+    // invalid key type
+    {
+        lengthTest: {
+            value: TMap(-1, 8, []),
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of map::ktype; ' +
+                         'expects one of the values in TYPE'
+            }
+        },
+        writeTest: {
+            value: TMap(-1, 8, []),
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of map::ktype; ' +
+                         'expects one of the values in TYPE'
+            }
+        },
+        readTest: {
+            bytes: [
+                0xff,                  // key_type:1 -- invalid (-1)
+                0x08,                  // val_type:1 -- invalid (-1)
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of map::ktype; ' +
+                         'expects one of the values in TYPE'
+            }
+        }
+    },
+
+    // invalid val type
+    {
+        lengthTest: {
+            value: TMap(8, -1, []),
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of map::vtype; ' +
+                         'expects one of the values in TYPE'
+            }
+        },
+        writeTest: {
+            value: TMap(8, -1, []),
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of map::vtype; ' +
+                         'expects one of the values in TYPE'
+            }
+        },
+        readTest: {
+            bytes: [
+                0x08,                  // key_type:1 -- invalid (-1)
+                0xff,                  // val_type:1 -- invalid (-1)
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of map::vtype; ' +
+                         'expects one of the values in TYPE'
+            }
+        }
+    }
+
+]));

--- a/test/tstruct.js
+++ b/test/tstruct.js
@@ -20,102 +20,99 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var Buffer = require('buffer').Buffer;
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
 
-    var Buffer = require('buffer').Buffer;
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
+var thriftrw = require('../index');
+var TStruct = thriftrw.TStruct;
+var TStructRW = thriftrw.TStructRW;
+var TField = thriftrw.TField;
 
-    var thriftrw = require('../index');
-    var TStruct = thriftrw.TStruct;
-    var TStructRW = thriftrw.TStructRW;
-    var TField = thriftrw.TField;
+test('TStructRW', testRW.cases(TStructRW, [
 
-    test('TStructRW', testRW.cases(TStructRW, [
+    [TStruct([TField(8, 1, 123)]), [
+        0x08,                   // type:1  -- i32
+        0x00, 0x01,             // id:2    -- 1
+        0x00, 0x00, 0x00, 0x7b, // Int32BE -- 123
+        0x00                    // type:1  -- stop
+    ]],
 
-        [TStruct([TField(8, 1, 123)]), [
-            0x08,                   // type:1  -- i32
-            0x00, 0x01,             // id:2    -- 1
-            0x00, 0x00, 0x00, 0x7b, // Int32BE -- 123
-            0x00                    // type:1  -- stop
-        ]],
+    [TStruct([TField(11, 1, Buffer('hello'))]), [
+        0x0b,                   // type:1 -- string
+        0x00, 0x01,             // id:2   -- 1
+        0x00, 0x00, 0x00, 0x05, // len:4  -- 5
+        0x68, 0x65, 0x6c, 0x6c, // chars  -- "hell"
+        0x6f,                   // chars  -- "o"
+        0x00                    // type:1 -- stop
+    ]],
 
-        [TStruct([TField(11, 1, Buffer('hello'))]), [
-            0x0b,                   // type:1 -- string
-            0x00, 0x01,             // id:2   -- 1
-            0x00, 0x00, 0x00, 0x05, // len:4  -- 5
-            0x68, 0x65, 0x6c, 0x6c, // chars  -- "hell"
-            0x6f,                   // chars  -- "o"
-            0x00                    // type:1 -- stop
-        ]],
+    [TStruct([
+        TField(3, 9, 20),
+        TField(6, 10, 10)
+    ]), [
+        0x03,       // type:1  -- byte
+        0x00, 0x09, // id:2    -- 9
+        0x14,       // byte:1  -- 20
+        0x06,       // type:1  -- i16
+        0x00, 0x0a, // id:2    -- 6
+        0x00, 0x0a, // Int16BE -- 10
+        0x00        // type:1  -- stop
+    ]],
 
-        [TStruct([
-            TField(3, 9, 20),
-            TField(6, 10, 10)
-        ]), [
-            0x03,       // type:1  -- byte
-            0x00, 0x09, // id:2    -- 9
-            0x14,       // byte:1  -- 20
-            0x06,       // type:1  -- i16
-            0x00, 0x0a, // id:2    -- 6
-            0x00, 0x0a, // Int16BE -- 10
-            0x00        // type:1  -- stop
-        ]],
+    [TStruct([
+        TField(12, 1, TStruct([TField(8, 1, 10)])),
+        TField(12, 2, TStruct([TField(11, 1, Buffer('hello'))]))
+    ]), [
+        0x0c,                   // type:1  -- struct
+        0x00, 0x01,             // id:2    -- 1
+        0x08,                   // type:1  -- i32
+        0x00, 0x01,             // id:2    -- 1
+        0x00, 0x00, 0x00, 0x0a, // Int32BE -- 10
+        0x00,                   // type:1  -- stop
+        0x0c,                   // type:1  -- struct
+        0x00, 0x02,             // id:2    -- 2
+        0x0b,                   // type:1  -- string
+        0x00, 0x01,             // id:2    -- 1
+        0x00, 0x00, 0x00, 0x05, // len:4   -- 5
+        0x68, 0x65, 0x6c, 0x6c, // chars   -- "hell"
+        0x6f,                   // chars   -- "o"
+        0x00,                   // type:1  -- stop
+        0x00                    // type:1  -- stop
+    ]],
 
-        [TStruct([
-            TField(12, 1, TStruct([TField(8, 1, 10)])),
-            TField(12, 2, TStruct([TField(11, 1, Buffer('hello'))]))
-        ]), [
-            0x0c,                   // type:1  -- struct
-            0x00, 0x01,             // id:2    -- 1
-            0x08,                   // type:1  -- i32
-            0x00, 0x01,             // id:2    -- 1
-            0x00, 0x00, 0x00, 0x0a, // Int32BE -- 10
-            0x00,                   // type:1  -- stop
-            0x0c,                   // type:1  -- struct
-            0x00, 0x02,             // id:2    -- 2
-            0x0b,                   // type:1  -- string
-            0x00, 0x01,             // id:2    -- 1
-            0x00, 0x00, 0x00, 0x05, // len:4   -- 5
-            0x68, 0x65, 0x6c, 0x6c, // chars   -- "hell"
-            0x6f,                   // chars   -- "o"
-            0x00,                   // type:1  -- stop
-            0x00                    // type:1  -- stop
-        ]],
-
-        {
-            lengthTest: {
-                value: TStruct([TField(-1, 1, null)]),
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of field::type; ' +
-                             'expects one of the values in TYPE'
-                }
-            },
-            writeTest: {
-                value: TStruct([TField(-1, 1, null)]),
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of field::type; ' +
-                             'expects one of the values in TYPE'
-                }
-            },
-            readTest: {
-                bytes: [
-                    0xff,       // type:1 -- invalid (-1)
-                    0x00, 0x01, // id:2   -- 1
-                    0x00        // type:1 -- stop
-                ],
-                error: {
-                    type: 'thrift-invalid-typeid',
-                    name: 'ThriftInvalidTypeidError',
-                    message: 'invalid typeid -1 of field::type; ' +
-                             'expects one of the values in TYPE'
-                }
+    {
+        lengthTest: {
+            value: TStruct([TField(-1, 1, null)]),
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of field::type; ' +
+                         'expects one of the values in TYPE'
+            }
+        },
+        writeTest: {
+            value: TStruct([TField(-1, 1, null)]),
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of field::type; ' +
+                         'expects one of the values in TYPE'
+            }
+        },
+        readTest: {
+            bytes: [
+                0xff,       // type:1 -- invalid (-1)
+                0x00, 0x01, // id:2   -- 1
+                0x00        // type:1 -- stop
+            ],
+            error: {
+                type: 'thrift-invalid-typeid',
+                name: 'ThriftInvalidTypeidError',
+                message: 'invalid typeid -1 of field::type; ' +
+                         'expects one of the values in TYPE'
             }
         }
+    }
 
-    ]));
-}
+]));

--- a/test/type-mismatch.js
+++ b/test/type-mismatch.js
@@ -20,13 +20,13 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var fs = require('fs');
-    var path = require('path');
+withLoader(function (loadThrift, test) {;
     var source = fs.readFileSync(path.join(__dirname, 'type-mismatch.thrift'), 'ascii');
-
     test('consts parse', function t(assert) {
         loadThrift({source: source}, function (err, thrift) {
             assert.throws(
@@ -37,4 +37,4 @@ module.exports = function(loadThrift) {
             assert.end();
         });
     });
-}
+});

--- a/test/type-mismatch.js
+++ b/test/type-mismatch.js
@@ -21,20 +21,21 @@
 'use strict';
 
 var test = require('tape');
+var Thrift = require('..').Thrift;
 var fs = require('fs');
 var path = require('path');
-var withLoader = require('./loader');
+var source = fs.readFileSync(path.join(__dirname, 'type-mismatch.thrift'), 'ascii');
 
-withLoader(function (loadThrift, test) {;
-    var source = fs.readFileSync(path.join(__dirname, 'type-mismatch.thrift'), 'ascii');
-    test('consts parse', function t(assert) {
-        loadThrift({source: source}, function (err, thrift) {
-            assert.throws(
-                function throws() { throw err; },
-                /type mismatch.*expects value, got service/,
-                'throws if service identified for value'
-            );
-            assert.end();
-        });
-    });
+test('consts parse', function t(assert) {
+    assert.throws(
+        typeMismatch,
+        /type mismatch.*expects value, got service/,
+        'throws if service identified for value'
+    );
+    assert.end();
+
+    function typeMismatch() {
+        return new Thrift({source: source});
+    }
 });
+

--- a/test/typedef.js
+++ b/test/typedef.js
@@ -24,33 +24,27 @@ var test = require('tape');
 var testRW = require('bufrw/test_rw');
 var fs = require('fs');
 var path = require('path');
-var withLoader = require('./loader');
+var Thrift = require('../thrift').Thrift;
 
-withLoader(function (loadThrift, test) {
-    var source = fs.readFileSync(path.join(__dirname, 'typedef.thrift'), 'ascii');
-    loadThrift({source: source}, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
+var source = fs.readFileSync(path.join(__dirname, 'typedef.thrift'), 'ascii');
+var thrift = new Thrift({source: source});
 
-        test('follows references through typedefs', function t(assert) {
-            assert.strictEqual(thrift.getType('Structure'), thrift.getType('Tree'));
-            assert.end();
-        });
-
-        test('Typedef rw', testRW.cases(thrift.Tree.rw, [
-
-            [new thrift.Tree({value: 0, children: []}), [
-                0x08,                   // typeid:1  -- 8, i32
-                0x00, 0x01,             // id:2      -- 1, "value"
-                0x00, 0x00, 0x00, 0x00, // value:4   -- 0
-                0x0f,                   // typeid:1  -- 15, list
-                0x00, 0x02,             // id:2      -- 2, "children"
-                0x0c,                   // el_type:1 -- struct
-                0x00, 0x00, 0x00, 0x00, // length:4  -- 0
-                0x00                    // typeid:1  -- 0, stop
-            ]]
-
-        ]));
-    });
+test('follows references through typedefs', function t(assert) {
+    assert.strictEqual(thrift.getType('Structure'), thrift.getType('Tree'));
+    assert.end();
 });
+
+test('Typedef rw', testRW.cases(thrift.Tree.rw, [
+
+    [new thrift.Tree({value: 0, children: []}), [
+        0x08,                   // typeid:1  -- 8, i32
+        0x00, 0x01,             // id:2      -- 1, "value"
+        0x00, 0x00, 0x00, 0x00, // value:4   -- 0
+        0x0f,                   // typeid:1  -- 15, list
+        0x00, 0x02,             // id:2      -- 2, "children"
+        0x0c,                   // el_type:1 -- struct
+        0x00, 0x00, 0x00, 0x00, // length:4  -- 0
+        0x00                    // typeid:1  -- 0, stop
+    ]]
+
+]));

--- a/test/typedef.js
+++ b/test/typedef.js
@@ -20,15 +20,19 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var fs = require('fs');
+var path = require('path');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var fs = require('fs');
-    var path = require('path');
-
+withLoader(function (loadThrift, test) {
     var source = fs.readFileSync(path.join(__dirname, 'typedef.thrift'), 'ascii');
     loadThrift({source: source}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
+
         test('follows references through typedefs', function t(assert) {
             assert.strictEqual(thrift.getType('Structure'), thrift.getType('Tree'));
             assert.end();
@@ -49,4 +53,4 @@ module.exports = function(loadThrift) {
 
         ]));
     });
-}
+});

--- a/test/union.js
+++ b/test/union.js
@@ -20,28 +20,30 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
+withLoader(function (loadThrift, test) {
+    loadThrift({source: 'union Foo { 1: i32 six, 2: i32 halfDozen }'}, function (err, thrift) {
+        if (err) {
+            throw err;
+        }
 
-   loadThrift({source: 'union Foo { 1: i32 six, 2: i32 halfDozen }'}, function (err, thrift) {
         test('UnionRW', testRW.cases(thrift.Foo.rw, [
-
             [new thrift.Foo({six: 6}), [
                 0x08,                      // type:1 -- 8 -- I32
                 0x00, 0x01,                // id:2   -- 1 -- six
                 0x00, 0x00, 0x00, 0x06,    // ok:1   -- 1 -- 6
                 0x00                       // type:1 -- 0 -- stop
             ]],
-
+            
             [new thrift.Foo({halfDozen: 6}), [
                 0x08,                      // type:1 -- 8 -- I32
                 0x00, 0x02,                // id:2   -- 1 -- halfDozen
                 0x00, 0x00, 0x00, 0x06,    // ok:1   -- 1 -- 6
                 0x00                       // type:1 -- 0 -- stop
             ]]
-
         ]));
     });
-}
+});

--- a/test/union.js
+++ b/test/union.js
@@ -22,28 +22,25 @@
 
 var test = require('tape');
 var testRW = require('bufrw/test_rw');
-var withLoader = require('./loader');
+var Thrift = require('../thrift').Thrift;
 
-withLoader(function (loadThrift, test) {
-    loadThrift({source: 'union Foo { 1: i32 six, 2: i32 halfDozen }'}, function (err, thrift) {
-        if (err) {
-            throw err;
-        }
+var thrift = new Thrift({source: 'union Foo { 1: i32 six, 2: i32 halfDozen }'});
 
-        test('UnionRW', testRW.cases(thrift.Foo.rw, [
-            [new thrift.Foo({six: 6}), [
-                0x08,                      // type:1 -- 8 -- I32
-                0x00, 0x01,                // id:2   -- 1 -- six
-                0x00, 0x00, 0x00, 0x06,    // ok:1   -- 1 -- 6
-                0x00                       // type:1 -- 0 -- stop
-            ]],
-            
-            [new thrift.Foo({halfDozen: 6}), [
-                0x08,                      // type:1 -- 8 -- I32
-                0x00, 0x02,                // id:2   -- 1 -- halfDozen
-                0x00, 0x00, 0x00, 0x06,    // ok:1   -- 1 -- 6
-                0x00                       // type:1 -- 0 -- stop
-            ]]
-        ]));
-    });
-});
+test('UnionRW', testRW.cases(thrift.Foo.rw, [
+
+    [new thrift.Foo({six: 6}), [
+        0x08,                      // type:1 -- 8 -- I32
+        0x00, 0x01,                // id:2   -- 1 -- six
+        0x00, 0x00, 0x00, 0x06,    // ok:1   -- 1 -- 6
+        0x00                       // type:1 -- 0 -- stop
+    ]],
+
+    [new thrift.Foo({halfDozen: 6}), [
+        0x08,                      // type:1 -- 8 -- I32
+        0x00, 0x02,                // id:2   -- 1 -- halfDozen
+        0x00, 0x00, 0x00, 0x06,    // ok:1   -- 1 -- 6
+        0x00                       // type:1 -- 0 -- stop
+    ]]
+
+]));
+

--- a/test/unrecognized-exception.js
+++ b/test/unrecognized-exception.js
@@ -20,20 +20,27 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var fs = require('fs');
+var path = require('path');
+var Buffer = require('buffer').Buffer;
+var withLoader = require('./loader');
 
-    var test = require('tape');
-    var fs = require('fs');
-    var path = require('path');
-    var Buffer = require('buffer').Buffer;
+var ThriftUnrecognizedException = require('../unrecognized-exception')
+    .ThriftUnrecognizedException;
 
-    var ThriftUnrecognizedException = require('../unrecognized-exception')
-        .ThriftUnrecognizedException;
+withLoader(function (loadThrift, test) {
 
     var sourceV1 = fs.readFileSync(path.join(__dirname, 'unrecognized-exception-v1.thrift'), 'ascii');
     var sourceV2 = fs.readFileSync(path.join(__dirname, 'unrecognized-exception-v2.thrift'), 'ascii');
     loadThrift({source: sourceV1}, function (err, thriftV1) {
+        if (err) {
+            throw err;
+        }
         loadThrift({source: sourceV2}, function (err, thriftV2) {
+            if (err) {
+                throw err;
+            }
+
             test('Exception RW', function t(assert) {
 
                 var err = new Error('Bogus Error: Voldemort');
@@ -85,4 +92,5 @@ module.exports = function(loadThrift) {
             });
         });
     });
-}
+
+});

--- a/test/unrecognized-exception.js
+++ b/test/unrecognized-exception.js
@@ -20,77 +20,66 @@
 
 'use strict';
 
+var test = require('tape');
 var fs = require('fs');
 var path = require('path');
 var Buffer = require('buffer').Buffer;
-var withLoader = require('./loader');
 
+var Thrift = require('../thrift').Thrift;
 var ThriftUnrecognizedException = require('../unrecognized-exception')
     .ThriftUnrecognizedException;
 
-withLoader(function (loadThrift, test) {
+var sourceV1 = fs.readFileSync(path.join(__dirname, 'unrecognized-exception-v1.thrift'), 'ascii');
+var sourceV2 = fs.readFileSync(path.join(__dirname, 'unrecognized-exception-v2.thrift'), 'ascii');
+var thriftV1 = new Thrift({source: sourceV1});
+var thriftV2 = new Thrift({source: sourceV2});
 
-    var sourceV1 = fs.readFileSync(path.join(__dirname, 'unrecognized-exception-v1.thrift'), 'ascii');
-    var sourceV2 = fs.readFileSync(path.join(__dirname, 'unrecognized-exception-v2.thrift'), 'ascii');
-    loadThrift({source: sourceV1}, function (err, thriftV1) {
-        if (err) {
-            throw err;
-        }
-        loadThrift({source: sourceV2}, function (err, thriftV2) {
-            if (err) {
-                throw err;
-            }
+test('Exception RW', function t(assert) {
 
-            test('Exception RW', function t(assert) {
+    var err = new Error('Bogus Error: Voldemort');
+    err.string = 'ThriftException';
+    err.bool = true;
+    err.byte = 0x00;
+    err.i16 = 0x1234;
+    err.i32 = 0x12345678;
+    err.i64 = Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+    err.double = 1;
+    err.binary = Buffer('binary');
+    err.struct = {
+        edges: {
+            'abc': 1,
+            'def': 2,
+            'ghi': 3
+        },
+        stringset: ['a', 'b', 'c'],
+        boollist: [true, true, false]
+    };
 
-                var err = new Error('Bogus Error: Voldemort');
-                err.string = 'ThriftException';
-                err.bool = true;
-                err.byte = 0x00;
-                err.i16 = 0x1234;
-                err.i32 = 0x12345678;
-                err.i64 = Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-                err.double = 1;
-                err.binary = Buffer('binary');
-                err.struct = {
-                    edges: {
-                        'abc': 1,
-                        'def': 2,
-                        'ghi': 3
-                    },
-                    stringset: ['a', 'b', 'c'],
-                    boollist: [true, true, false]
-                };
-
-                var v2Result = new thriftV2.BogusService.bogus.result.Constructor({
-                    bogusErr: err
-                });
-
-                var v2Buf = thriftV2.BogusService.bogus.result.toBuffer(v2Result);
-
-                var v1Result = thriftV1.BogusService.bogus.result.fromBuffer(v2Buf);
-
-                assert.deepEqual(v1Result, {
-                    success: null,
-                    failure: new ThriftUnrecognizedException({
-                        1: err.string,
-                        2: err.bool,
-                        3: err.byte,
-                        4: err.i16,
-                        5: err.i32,
-                        6: err.i64,
-                        7: err.double,
-                        8: 'binary',
-                        9: {
-                            1: err.struct.edges,
-                            2: err.struct.stringset,
-                            3: err.struct.boollist
-                        }
-                    })
-                }, 'Expected ThriftUnrecognizedException on result failure property');
-                assert.end();
-            });
-        });
+    var v2Result = new thriftV2.BogusService.bogus.result.Constructor({
+        bogusErr: err
     });
 
+    var v2Buf = thriftV2.BogusService.bogus.result.toBuffer(v2Result);
+
+    var v1Result = thriftV1.BogusService.bogus.result.fromBuffer(v2Buf);
+
+    assert.deepEqual(v1Result, {
+        success: null,
+        failure: new ThriftUnrecognizedException({
+            1: err.string,
+            2: err.bool,
+            3: err.byte,
+            4: err.i16,
+            5: err.i32,
+            6: err.i64,
+            7: err.double,
+            8: 'binary',
+            9: {
+                1: err.struct.edges,
+                2: err.struct.stringset,
+                3: err.struct.boollist
+            }
+        })
+    }, 'Expected ThriftUnrecognizedException on result failure property');
+    assert.end();
 });

--- a/test/void.js
+++ b/test/void.js
@@ -20,25 +20,22 @@
 
 'use strict';
 
-module.exports = function(loadThrift) {
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var testThrift = require('./thrift-test');
 
-    var test = require('tape');
-    var testRW = require('bufrw/test_rw');
-    var testThrift = require('./thrift-test');
+var thriftrw = require('../index');
+var VoidRW = thriftrw.VoidRW;
+var ThriftVoid = thriftrw.ThriftVoid;
+var TYPE = require('../TYPE');
 
-    var thriftrw = require('../index');
-    var VoidRW = thriftrw.VoidRW;
-    var ThriftVoid = thriftrw.ThriftVoid;
-    var TYPE = require('../TYPE');
+var validTestCases = [
+    [null, []]
+];
 
-    var validTestCases = [
-        [null, []]
-    ];
+var testCases = [].concat(
+    validTestCases
+);
 
-    var testCases = [].concat(
-        validTestCases
-    );
-
-    test('VoidRW', testRW.cases(VoidRW, testCases));
-    test('ThriftVoid', testThrift(ThriftVoid, VoidRW, TYPE.VOID));
-}
+test('VoidRW', testRW.cases(VoidRW, testCases));
+test('ThriftVoid', testThrift(ThriftVoid, VoidRW, TYPE.VOID));

--- a/thrift.js
+++ b/thrift.js
@@ -71,20 +71,13 @@ function Thrift(options) {
 
 // Alternative constructor allowing for asynchronous source loading.
 Thrift.load = function load(options, cb) {
-    if (!options) {
-        return cb(Error('options required'));
-    } else if (typeof options !== 'object') {
-        return cb(Error('options must be object'));
-    } else if (!options.fs || !options.fs.readFile) {
-        return cb(Error('options.fs.readFile required'));
-    }
+    assert(options != null, 'options required');
+    assert(typeof options === 'object', 'options must be object');
+    assert(options.fs != null && typeof options.fs.readFile === 'function',
+        'options.fs.readFile is required for async loading');
+
     options.asyncReadFile = true;
-    var thrift;
-    try {
-        thrift = new Thrift(options);
-    } catch (err) {
-        return cb(err, undefined);
-    }
+    var thrift = new Thrift(options);
     thrift._asyncParse(thrift.filename, thrift.allowIncludeAlias, function (err) {
         if (err) {
             return cb(err, undefined);


### PR DESCRIPTION
Individual test modules can be run in isolation.

This change refactors the async/sync loading wrapper such that it can be used as a utility instead of a scaffold for running tests.

The change also withdraws the use of the loader wrapper for the test cases that make no use of the module loader.

Most tests use a source string or a static file.

Evidently, the infrastructure for browser testing allows for synchronously reading static assets in tests.