### PR TITLE
Address Node.js Buffer constructor deprecations

### DIFF
--- a/benchmarks/cases.js
+++ b/benchmarks/cases.js
@@ -20,8 +20,7 @@
 
 'use strict';
 
-/* global Buffer */
-
+var Buffer = require('buffer').Buffer;
 var WriteResult = require('bufrw/base').WriteResult;
 var ReadResult = require('bufrw/base').ReadResult;
 var LengthResult = require('bufrw/base').LengthResult;

--- a/benchmarks/cases.js
+++ b/benchmarks/cases.js
@@ -34,7 +34,7 @@ function JsonCase(args) {
 JsonCase.prototype.bench = function benchJsonCase() {
     var text = JSON.stringify(this.payload);
     var length = Buffer.byteLength(text, 'utf8');
-    var buffer = new Buffer(length);
+    var buffer = (Buffer.alloc || Buffer)(length);
     buffer.write(text, 0, 'utf8');
     text = buffer.toString('utf8', 0, length);
     var payload = JSON.parse(text);
@@ -51,7 +51,7 @@ var writeRes = new WriteResult();
 var readRes = new ReadResult();
 ThriftCase.prototype.bench = function benchThriftCase() {
     this.rw.poolByteLength(lenRes, this.payload);
-    var buffer = new Buffer(lenRes.length);
+    var buffer = (Buffer.alloc || Buffer)(lenRes.length);
     this.rw.poolWriteInto(writeRes, this.payload, buffer, 0);
     this.rw.poolReadFrom(readRes, buffer, 0);
 };

--- a/binary.js
+++ b/binary.js
@@ -18,9 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global Buffer */
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var bufrw = require('bufrw');
 var TYPE = require('./TYPE');
 

--- a/i64.js
+++ b/i64.js
@@ -182,6 +182,8 @@ function I64BufferRW() {}
 util.inherits(I64BufferRW, I64RW);
 
 I64BufferRW.prototype.poolReadFrom = function poolReadTInt64From(destResult, buffer, offset) {
+    // The following branches right only on legacy versions of Node.js
+    // istanbul ignore next
     var value = (Buffer.alloc || Buffer)(8);
     buffer.copy(value, 0, offset, offset + 8);
     return destResult.reset(null, offset + 8, value);

--- a/i64.js
+++ b/i64.js
@@ -182,7 +182,7 @@ function I64BufferRW() {}
 util.inherits(I64BufferRW, I64RW);
 
 I64BufferRW.prototype.poolReadFrom = function poolReadTInt64From(destResult, buffer, offset) {
-    var value = new Buffer(8);
+    var value = (Buffer.alloc || Buffer)(8);
     buffer.copy(value, 0, offset, offset + 8);
     return destResult.reset(null, offset + 8, value);
 };

--- a/i64.js
+++ b/i64.js
@@ -18,10 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global Buffer */
 /* eslint no-self-compare: [0] */
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var util = require('util');
 var bufrw = require('bufrw');
 var Long = require('long');

--- a/test/enum.js
+++ b/test/enum.js
@@ -51,7 +51,7 @@ test('round trip an enum', function t(assert) {
 test('first enum is 0 by default', function t(assert) {
     var inStruct = {me2_2: null, me3_n2: null, me3_d1: 'ME3_0'};
     var buffer = MyStruct.toBuffer(inStruct);
-    var expected = new Buffer([
+    var expected = (Buffer.from || Buffer)([
         0x08, 0x00, // struct
         0x03, // field number 3
         0x00, 0x00, 0x00, 0x00, // value 0
@@ -64,7 +64,7 @@ test('first enum is 0 by default', function t(assert) {
 test('count resumes from previous enum', function t(assert) {
     var inStruct = {me2_2: null, me3_n2: null, me3_d1: 'ME3_N1'};
     var buffer = MyStruct.toBuffer(inStruct);
-    var expected = new Buffer([
+    var expected = (Buffer.from || Buffer)([
         0x08,                   // typeid:1 -- 8, struct
         0x00, 0x03,             // field:2  -- 3
         0xff, 0xff, 0xff, 0xff, // value~4  -- -1
@@ -77,7 +77,7 @@ test('count resumes from previous enum', function t(assert) {
 test('duplicate name permitted', function t(assert) {
     var inStruct = {me2_2: null, me3_n2: null, me3_d1: 'ME3_D0'};
     var buffer = MyStruct.toBuffer(inStruct);
-    var expected = new Buffer([
+    var expected = (Buffer.from || Buffer)([
         0x08,                   // typeid:1 -- 0, struct
         0x00, 0x03,             // field~2  -- 3
         0x00, 0x00, 0x00, 0x00, // value~4  -- 0
@@ -133,7 +133,7 @@ test('can\'t encode unknown name', function t(assert) {
 });
 
 test('can\'t decode unknown number', function t(assert) {
-    var buffer = new Buffer([
+    var buffer = (Buffer.from || Buffer)([
         0x08,                   // typeid:1  -- 8, struct
         0x00, 0x03,             // fieldid:2 -- 3
         0x00, 0x00, 0x00, 0x0b, // value:4   -- 11

--- a/test/enum.js
+++ b/test/enum.js
@@ -18,11 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global Buffer */
 /* eslint camelcase:[0] */
 /* eslint no-new:[0] */
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var test = require('tape');
 var fs = require('fs');
 var path = require('path');

--- a/test/i64.js
+++ b/test/i64.js
@@ -41,7 +41,7 @@ var dateRW = thrift.getType('timestamp').rw;
 
 var bufferCases = [
     [
-        Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
+        (Buffer.from || Buffer)([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
         [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
         {
             readTest: {
@@ -107,11 +107,11 @@ var longCases = [
 ];
 
 test('I64LongRW negatives', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     longRW.poolWriteInto({
         reset: function (val, err) {}
     }, -1, buffer, 0);
-    assert.deepEquals(buffer, new Buffer('ffffffffffffffff', 'hex'), 'writen value is negative')
+    assert.deepEquals(buffer, (Buffer.from || Buffer)('ffffffffffffffff', 'hex'), 'writen value is negative')
     assert.end();
 });
 
@@ -156,16 +156,16 @@ var dateCases = [
 test('I64DateRW', testRW.cases(dateRW, dateCases));
 
 test('coerce string', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto('0102030405060708', buffer, 0);
     assert.ifError(res.err, 'write into buffer');
     assert.equals(res.offset, 8, 'offset after write');
-    assert.deepEquals(buffer, new Buffer('0102030405060708', 'hex'), 'written value');
+    assert.deepEquals(buffer, (Buffer.from || Buffer)('0102030405060708', 'hex'), 'written value');
     assert.end();
 });
 
 test('fail to coerce string of bad length', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto('01020304050607', buffer, 0);
     assert.equals(res.err.message,
         'invalid argument, expected a string of 16 hex characters, or other i64 representation', 'string length error');
@@ -173,7 +173,7 @@ test('fail to coerce string of bad length', function t(assert) {
 });
 
 test('fail to coerce string of bad hi value', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto('--------05060708', buffer, 0);
     assert.equals(
         res.err.message,
@@ -183,7 +183,7 @@ test('fail to coerce string of bad hi value', function t(assert) {
 });
 
 test('fail to coerce string of bad lo value', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto('01020304--------', buffer, 0);
     assert.equals(res.err.message,
         'invalid argument, expected a string of hex characters, or other i64 representation',
@@ -192,16 +192,16 @@ test('fail to coerce string of bad lo value', function t(assert) {
 });
 
 test('coerce {hi[gh], lo[w]} object to i32 on wire', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto({hi: 1, lo: 2}, buffer, 0);
     assert.ifError(res.err, 'write into buffer');
     assert.equals(res.offset, 8, 'offset after write');
-    assert.deepEquals(buffer, new Buffer('0000000100000002', 'hex'), 'wrote hi[gh], lo[w] to buffer');
+    assert.deepEquals(buffer, (Buffer.from || Buffer)('0000000100000002', 'hex'), 'wrote hi[gh], lo[w] to buffer');
     assert.end();
 });
 
 test('fail to coerce object bad hi value', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto({hi: null, lo: 0}, buffer, 0);
     assert.equals(res.err.message,
         'invalid argument, expected {hi[gh], lo[w]} with high bits, or other i64 representation',
@@ -210,7 +210,7 @@ test('fail to coerce object bad hi value', function t(assert) {
 });
 
 test('fail to coerce object bad lo value', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto({hi: 0, lo: null}, buffer, 0);
     assert.equals(res.err.message,
         'invalid argument, expected {hi[gh], lo[w]} with low bits, or other i64 representation',
@@ -219,34 +219,34 @@ test('fail to coerce object bad lo value', function t(assert) {
 });
 
 test('coerce small number', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto(10, buffer, 0);
     assert.ifError(res.err, 'write into buffer');
     assert.equals(res.offset, 8, 'offset after write');
-    assert.deepEquals(buffer, new Buffer('000000000000000a', 'hex'), 'written value');
+    assert.deepEquals(buffer, (Buffer.from || Buffer)('000000000000000a', 'hex'), 'written value');
     assert.end();
 });
 
 test('coerce large number', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto(Math.pow(2, 50), buffer, 0);
     assert.ifError(res.err, 'write into buffer');
     assert.equals(res.offset, 8, 'offset after write');
-    assert.deepEquals(buffer, new Buffer('0004000000000000', 'hex'), 'written value');
+    assert.deepEquals(buffer, (Buffer.from || Buffer)('0004000000000000', 'hex'), 'written value');
     assert.end();
 });
 
 test('coerce array of bytes', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto([1, 2, 3, 4, 5, 6, 7, 8], buffer, 0);
     assert.ifError(res.err, 'write into buffer');
     assert.equals(res.offset, 8, 'offset after write');
-    assert.deepEquals(buffer, new Buffer('0102030405060708', 'hex'), 'written value');
+    assert.deepEquals(buffer, (Buffer.from || Buffer)('0102030405060708', 'hex'), 'written value');
     assert.end();
 });
 
 test('fail to coerce array with bad length', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto([1, 2, 3, 4, 5, 6, 7, 8, 9], buffer, 0);
     assert.equals(res.err.message,
         'invalid argument, expected an array of 8 bytes, or other i64 representation',
@@ -255,42 +255,42 @@ test('fail to coerce array with bad length', function t(assert) {
 });
 
 test('fail to coerce', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     var res = bufferRW.writeInto(null, buffer, 0);
     assert.equals(res.err.message, 'invalid argument, expected i64 representation');
     assert.end();
 });
 
 test('coerce date string', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     buffer.fill(0xff);
     dateRW.writeInto('1970-01-01T00:00:00.000Z', buffer, 0);
-    assert.deepEquals(buffer, new Buffer([0, 0, 0, 0, 0, 0, 0, 0]), 'coerces date string');
+    assert.deepEquals(buffer, (Buffer.from || Buffer)([0, 0, 0, 0, 0, 0, 0, 0]), 'coerces date string');
     assert.end();
 });
 
 test('coerce number to date', function t(assert) {
-    var buffer = new Buffer(8);
+    var buffer = (Buffer.alloc || Buffer)(8);
     dateRW.writeInto(0, buffer, 0);
-    assert.deepEquals(buffer, new Buffer([0, 0, 0, 0, 0, 0, 0, 0]), 'coerces number to date');
+    assert.deepEquals(buffer, (Buffer.from || Buffer)([0, 0, 0, 0, 0, 0, 0, 0]), 'coerces number to date');
     assert.end();
 });
 
 test('Accepts buffer as date', function t(assert) {
-    var outBuffer = new Buffer(8);
+    var outBuffer = (Buffer.alloc || Buffer)(8);
     outBuffer.fill(0xff);
-    var inbuffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8]);
+    var inbuffer = (Buffer.from || Buffer)([1, 2, 3, 4, 5, 6, 7, 8]);
     dateRW.writeInto(inbuffer, outBuffer, 0);
     assert.deepEquals(outBuffer, inbuffer, 'accepts date buffer');
     assert.end();
 });
 
 test('Accepts array as date', function t(assert) {
-    var outBuffer = new Buffer(8);
+    var outBuffer = (Buffer.alloc || Buffer)(8);
     outBuffer.fill(0xff);
     var inArray = [1, 2, 3, 4, 5, 6, 7, 8];
     dateRW.writeInto(inArray, outBuffer, 0);
-    assert.deepEquals(outBuffer, new Buffer(inArray), 'accepts date buffer');
+    assert.deepEquals(outBuffer, (Buffer.from || Buffer)(inArray), 'accepts date buffer');
     assert.end();
 });
 

--- a/test/i8.js
+++ b/test/i8.js
@@ -72,9 +72,9 @@ var invalidArgumentTestCases = [
     'hello',
     [],
     {},
-    Buffer(1),
-    Buffer([0]),
-    Buffer('string')
+    (Buffer.alloc || Buffer)(1),
+    (Buffer.from || Buffer)([0]),
+    (Buffer.from || Buffer)('string')
 ].map(invalidArgumentTestCase('number'));
 
 var invalidShortBufferTestCases = [{

--- a/test/message.js
+++ b/test/message.js
@@ -18,10 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global Buffer */
 /* eslint max-len:[0, 120] */
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var test = require('tape');
 var path = require('path');
 var fs = require('fs');

--- a/test/message.js
+++ b/test/message.js
@@ -42,11 +42,11 @@ test('round-trip a non-strict message', function t(assert) {
     });
 
     var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
-    var buffer = new Buffer(result.length);
+    var buffer = (Buffer.alloc || Buffer)(result.length);
 
     var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
 
-    var expectedBuffer = new Buffer([
+    var expectedBuffer = (Buffer.from || Buffer)([
         0x00, 0x00, 0x00, 0x03, // name.length:4
         0x66, 0x6f, 0x6f,       // name:name.length
         0x01,                   // type:1 = CALL
@@ -81,10 +81,10 @@ test('round-trip a non-strict message', function t(assert) {
     });
 
     var result = thrift.Service.foo.argumentsMessageRW.byteLength(message);
-    var buffer = new Buffer(result.length);
+    var buffer = (Buffer.alloc || Buffer)(result.length);
     var result = thrift.Service.foo.argumentsMessageRW.writeInto(message, buffer, 0);
 
-    var expectedBuffer = new Buffer([
+    var expectedBuffer = (Buffer.from || Buffer)([
         0x80,                   // strict
         0x01,                   // version = 1
         0x00,                   // shrug
@@ -121,7 +121,7 @@ test('round trip an exception (legacy)', function t(assert) {
         })
     });
 
-    var expectedBuffer = new Buffer([
+    var expectedBuffer = (Buffer.from || Buffer)([
         0x00, 0x00, 0x00, 0x03, // name.length:4
         0x66, 0x6f, 0x6f,       // name:name.length -- "foo"
         0x03,                   // type:3 = EXCEPTION
@@ -143,7 +143,7 @@ test('round trip an exception (legacy)', function t(assert) {
     var result = thrift.Service.foo.resultMessageRW.byteLength(message);
     assert.equal(result.length, expectedBuffer.length, 'measured correctly');
 
-    var buffer = new Buffer(result.length);
+    var buffer = (Buffer.alloc || Buffer)(result.length);
     buffer.fill(0xCC);
 
     var result = thrift.Service.foo.resultMessageRW.writeInto(message, buffer, 0);
@@ -160,7 +160,7 @@ test('round trip an exception (legacy)', function t(assert) {
 });
 
 test('read unexpected version error', function t(assert) {
-    var buffer = new Buffer([
+    var buffer = (Buffer.from || Buffer)([
         0x80,                   // strict
         0x02,                   // version = 2 XXX BUT WHAT IS GOING ON WITH VERSION 2!?
         0x00,                   // shrug
@@ -186,7 +186,7 @@ test('read unexpected version error', function t(assert) {
 });
 
 test('read unexpected version error for undefined bits of strict', function t(assert) {
-    var buffer = new Buffer([
+    var buffer = (Buffer.from || Buffer)([
         0x81,                   // strict XXX BUT WHAT IS GOING ON WITH THIS LOW BIT!?
         0x01,                   // version = 1
         0x00,                   // shrug
@@ -212,7 +212,7 @@ test('read unexpected version error for undefined bits of strict', function t(as
 });
 
 test('read unrecognized message type error (strict)', function t(assert) {
-    var buffer = new Buffer([
+    var buffer = (Buffer.from || Buffer)([
         0x80,                   // strict
         0x01,                   // version = 1
         0x00,                   // shrug
@@ -240,7 +240,7 @@ test('read unrecognized message type error (strict)', function t(assert) {
 });
 
 test('read unrecognized message type error (legacy)', function t(assert) {
-    var buffer = new Buffer([
+    var buffer = (Buffer.from || Buffer)([
         0x00, 0x00, 0x00, 0x03, // name.length:4
         0x66, 0x6f, 0x6f,       // name:name.length
         0xff,                   // type:1 = XXX WAT!?
@@ -265,7 +265,7 @@ test('read unrecognized message type error (legacy)', function t(assert) {
 });
 
 test('read invalid message body error', function t(assert) {
-    var buffer = new Buffer([
+    var buffer = (Buffer.from || Buffer)([
         0x00, 0x00, 0x00, 0x03, // name.length:4
         0x66, 0x6f, 0x6f,       // name:name.length
         0x01,                   // type:1 = CALL
@@ -285,7 +285,7 @@ test('read invalid message body error', function t(assert) {
 });
 
 test('read exception', function t(assert) {
-    var buffer = new Buffer([
+    var buffer = (Buffer.from || Buffer)([
         0x00, 0x00, 0x00, 0x03, // name.length:4
         0x66, 0x6f, 0x6f,       // name:name.length
         0x03,                   // type:3 = EXCEPTION
@@ -312,7 +312,7 @@ test('read exception', function t(assert) {
 });
 
 test('read invalid exception', function t(assert) {
-    var buffer = new Buffer([
+    var buffer = (Buffer.from || Buffer)([
         0x00, 0x00, 0x00, 0x03, // name.length:4
         0x66, 0x6f, 0x6f,       // name:name.length
         0x03,                   // type:3 = EXCEPTION
@@ -332,7 +332,7 @@ test('read invalid exception', function t(assert) {
 });
 
 test('write invalid message type (legacy)', function t(assert) {
-    var buffer = new Buffer(255);
+    var buffer = (Buffer.alloc || Buffer)(255);
     var message = {
         name: 'foo',
         type: 'BORK',
@@ -345,7 +345,7 @@ test('write invalid message type (legacy)', function t(assert) {
 });
 
 test('write invalid message type (strict)', function t(assert) {
-    var buffer = new Buffer(255);
+    var buffer = (Buffer.alloc || Buffer)(255);
     var message = {
         name: 'foo',
         type: 'BORK',
@@ -358,7 +358,7 @@ test('write invalid message type (strict)', function t(assert) {
 });
 
 test('measure byte length for invalid body', function t(assert) {
-    var buffer = new Buffer(255);
+    var buffer = (Buffer.alloc || Buffer)(255);
     var message = {
         name: 'foo',
         type: 'BORK',
@@ -376,7 +376,7 @@ test('measure byte length for invalid body', function t(assert) {
 });
 
 test('measure byte length for invalid exception', function t(assert) {
-    var buffer = new Buffer(255);
+    var buffer = (Buffer.alloc || Buffer)(255);
     var message = {
         name: 'foo',
         type: 'EXCEPTION',

--- a/test/set.js
+++ b/test/set.js
@@ -166,7 +166,7 @@ test('Struct with set rw', testRW.cases(thrift.Bucket.rw, [
 ]));
 
 test('Tolerance for lists on the wire', function t(assert) {
-    var buf = new Buffer([
+    var buf = (Buffer.from || Buffer)([
         0x0f,                   // type:1      -- 15, list
         0x00, 0x01,             // field:2     -- 1, asArray
         0x08,                   // type:1      -- 8, i32

--- a/test/set.js
+++ b/test/set.js
@@ -18,10 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global Buffer */
-
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var test = require('tape');
 var testRW = require('bufrw/test_rw');
 var fs = require('fs');

--- a/test/skip.js
+++ b/test/skip.js
@@ -18,9 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global Buffer */
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var test = require('tape');
 var formatError = require('bufrw/interface').formatError;
 var skip = require('../skip').skipField;

--- a/test/skip.js
+++ b/test/skip.js
@@ -165,7 +165,7 @@ test('skip map of strings to i32s', createCase([
 function createCase(bytes) {
     return function t(assert) {
         var res = new ReadResult();
-        var result = skip(res, new Buffer(bytes), 0);
+        var result = skip(res, (Buffer.from || Buffer)(bytes), 0);
         if (result.err) {
             assert.comment(formatError(result.err), {color: true});
             return assert.end(result.err);
@@ -178,7 +178,7 @@ function createCase(bytes) {
 test('skip short buffer', function t(assert) {
     var bytes = [];
     var res = new ReadResult();
-    var result = skip(res, new Buffer(bytes), 0);
+    var result = skip(res, (Buffer.from || Buffer)(bytes), 0);
     assert.ok(result.err !== null);
     assert.end();
 });

--- a/test/struct-skip.js
+++ b/test/struct-skip.js
@@ -32,7 +32,7 @@ var thrift = new Thrift({source: source});
 var Health = thrift.$Health;
 
 test('skip void', function t(assert) {
-    var result = Health.rw.readFrom(new Buffer([
+    var result = Health.rw.readFrom((Buffer.from || Buffer)([
         0x02,                     // type:1   -- 2 -- BOOL
         0x00, 0x02,               // id:2     -- 2 -- WHAT EVEN IS!?
         0x00,                     // bool:1
@@ -47,7 +47,7 @@ test('skip void', function t(assert) {
 });
 
 test('string', function t(assert) {
-    var result = Health.rw.readFrom(new Buffer([
+    var result = Health.rw.readFrom((Buffer.from || Buffer)([
         11,                       // typeid:1 -- 11 -- STRING
         0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
         0x00, 0x00, 0x00, 0x02,   // len~4
@@ -62,7 +62,7 @@ test('string', function t(assert) {
 });
 
 test('struct', function t(assert) {
-    var result = Health.rw.readFrom(new Buffer([
+    var result = Health.rw.readFrom((Buffer.from || Buffer)([
         12,                       // typeid:1 -- 12 -- STRUCT
         0x00, 0x02,               // id:2     -- 2  -- ?
         11,                       //   typeid:1 -- 11 -- STRING
@@ -80,7 +80,7 @@ test('struct', function t(assert) {
 });
 
 test('map', function t(assert) {
-    var result = Health.rw.readFrom(new Buffer([
+    var result = Health.rw.readFrom((Buffer.from || Buffer)([
         0x0d,                   // typeid:1           -- 13, map
         0x00, 0x02,             // id:2               -- 2 UNKNOWN
 
@@ -134,7 +134,7 @@ test('map', function t(assert) {
 });
 
 test('list', function t(assert) {
-    var result = Health.rw.readFrom(new Buffer([
+    var result = Health.rw.readFrom((Buffer.from || Buffer)([
         0x02,                     // type:1      -- 2 BOOL
         0x00, 0x02,               // id:2        -- 2 UNKNOWN
         0x0f,                     // typeid:1    -- 15, list

--- a/test/struct.js
+++ b/test/struct.js
@@ -90,18 +90,18 @@ test('HealthRW', testRW.cases(Health.rw, cases));
 
 test('HealthRW to Buffer', function t(assert) {
     var res = Health.rw.toBuffer(cases[0][0]);
-    assert.deepEqual(res.value, new Buffer(cases[0][1]), 'buffer matches');
+    assert.deepEqual(res.value, (Buffer.from || Buffer)(cases[0][1]), 'buffer matches');
     assert.end();
 });
 
 test('HealthRW from Buffer', function t(assert) {
-    var res = Health.rw.fromBuffer(new Buffer(cases[0][1]));
+    var res = Health.rw.fromBuffer((Buffer.from || Buffer)(cases[0][1]));
     assert.deepEqual(res.value, cases[0][0], 'object matches');
     assert.end();
 });
 
 test('complains of missing required field', function t(assert) {
-    var res = Health.rw.readFrom(new Buffer([
+    var res = Health.rw.readFrom((Buffer.from || Buffer)([
         0x00                      // typeid:1 -- 0 -- STOP
     ]), 0);
     assert.ok(res.err, 'required field error');
@@ -111,7 +111,7 @@ test('complains of missing required field', function t(assert) {
 });
 
 test('struct skips unknown void', function t(assert) {
-    var res = Health.rw.readFrom(new Buffer([
+    var res = Health.rw.readFrom((Buffer.from || Buffer)([
         0x02,                     // type:1   -- 2 -- BOOL
         0x00, 0x02,               // id:2     -- 2 -- WHAT EVEN IS!?
         0x00,                     // bool:1
@@ -130,7 +130,7 @@ test('struct skips unknown void', function t(assert) {
 });
 
 test('fails to read unexpected typeid for known field', function t(assert) {
-    var buffer = new Buffer([
+    var buffer = (Buffer.from || Buffer)([
         0x01,       // typeid:1 -- 1 -- VOID
         0x00, 0x01, // fid:2    -- 1 -- ok
         0x00        // typeid:1 -- 0 -- STOP
@@ -146,7 +146,7 @@ test('fails to read unexpected typeid for known field', function t(assert) {
 });
 
 test('struct skips unknown string', function t(assert) {
-    var res = Health.rw.readFrom(new Buffer([
+    var res = Health.rw.readFrom((Buffer.from || Buffer)([
         0x02,                     // type:1   -- 2 -- BOOL
         0x00, 0x01,               // id:2     -- 1 -- ok
         0x01,                     // ok:1     -- 1 -- true
@@ -166,7 +166,7 @@ test('struct skips unknown string', function t(assert) {
 });
 
 test('struct skips unknown struct', function t(assert) {
-    var res = Health.rw.readFrom(new Buffer([
+    var res = Health.rw.readFrom((Buffer.from || Buffer)([
         0x02,                     // type:1   -- 2 -- BOOL
         0x00, 0x01,               // id:2     -- 1 -- ok
         0x01,                     // ok:1     -- 1 -- true
@@ -192,7 +192,7 @@ test('struct skips unknown struct', function t(assert) {
 });
 
 test('struct skips uknown map', function t(assert) {
-    var res = Health.rw.readFrom(new Buffer([
+    var res = Health.rw.readFrom((Buffer.from || Buffer)([
         0x02,                     // type:1   -- 2 BOOL
         0x00, 0x01,               // id:2     -- 1 ok
         0x01,                     // ok:1     -- 1 true
@@ -250,7 +250,7 @@ test('struct skips uknown map', function t(assert) {
 });
 
 test('struct skips unknown list', function t(assert) {
-    var res = Health.rw.readFrom(new Buffer([
+    var res = Health.rw.readFrom((Buffer.from || Buffer)([
         0x02,                     // type:1   -- 2 BOOL
         0x00, 0x01,               // id:2     -- 1 ok
         0x00,                     // ok:1     -- 0 false
@@ -347,7 +347,7 @@ test('required fields are required on measuring byte length', function t(assert)
 
 test('required fields are required on writing into buffer', function t(assert) {
     var health = new Health();
-    var res = Health.rw.writeInto(health, new Buffer(100), 0);
+    var res = Health.rw.writeInto(health, (Buffer.alloc || Buffer)(100), 0);
     if (!res.err) {
         assert.fail('should fail to write');
         return assert.end();
@@ -455,11 +455,11 @@ test('skips optional elided arguments', function t(assert) {
     if (byteLengthRes.err) return assert.end(byteLengthRes.err);
     assert.equal(byteLengthRes.length, 1, 'only needs one byte');
 
-    var buffer = new Buffer(byteLengthRes.length);
+    var buffer = (Buffer.alloc || Buffer)(byteLengthRes.length);
     var writeRes = thrift.rw.writeInto(health, buffer, 0);
     if (writeRes.err) return assert.end(writeRes.err);
     assert.equal(writeRes.offset, 1, 'writes to end of buffer');
-    assert.deepEqual(buffer, new Buffer([0x00]), 'writes stop byte only');
+    assert.deepEqual(buffer, (Buffer.from || Buffer)([0x00]), 'writes stop byte only');
 
     assert.end();
 });
@@ -487,11 +487,11 @@ test('skips optional elided struct (all fields optional)', function t(assert) {
     if (byteLengthRes.err) return assert.end(byteLengthRes.err);
     assert.equal(byteLengthRes.length, 1, 'only needs one byte');
 
-    var buffer = new Buffer(byteLengthRes.length);
+    var buffer = (Buffer.alloc || Buffer)(byteLengthRes.length);
     var writeRes = thrift.rw.writeInto(null, buffer, 0);
     if (writeRes.err) return assert.end(writeRes.err);
     assert.equal(writeRes.offset, 1, 'writes to end of buffer');
-    assert.deepEqual(buffer, new Buffer([0x00]), 'writes stop byte only');
+    assert.deepEqual(buffer, (Buffer.from || Buffer)([0x00]), 'writes stop byte only');
 
     assert.end();
 });

--- a/test/struct.js
+++ b/test/struct.js
@@ -18,10 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global Buffer */
 /* eslint max-len:[0, 120] */
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var test = require('tape');
 var testRW = require('bufrw/test_rw');
 var Literal = require('../ast').Literal;

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -89,7 +89,7 @@ test('can get type from thrift', function t(assert) {
 });
 
 test('can read struct from buffer', function t(assert) {
-    var struct = thrift.Struct.fromBuffer(new Buffer([
+    var struct = thrift.Struct.fromBuffer((Buffer.from || Buffer)([
         0x08, // typeid:1 -- 8, i32
         0x00, 0x01, // id:2 -- 1, "number"
         0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
@@ -101,7 +101,7 @@ test('can read struct from buffer', function t(assert) {
 });
 
 test('can read struct result from buffer', function t(assert) {
-    var result = thrift.Struct.fromBufferResult(new Buffer([
+    var result = thrift.Struct.fromBufferResult((Buffer.from || Buffer)([
         0x08, // typeid:1 -- 8, i32
         0x00, 0x01, // id:2 -- 1, "number"
         0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
@@ -114,7 +114,7 @@ test('can read struct result from buffer', function t(assert) {
 
 test('can write struct to buffer', function t(assert) {
     var buffer = thrift.Struct.toBuffer(new thrift.Struct({number: 10}));
-    assert.deepEqual(buffer, new Buffer([
+    assert.deepEqual(buffer, (Buffer.from || Buffer)([
         0x08, // typeid:1 -- 8, i32
         0x00, 0x01, // id:2 -- 1, "number"
         0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
@@ -125,7 +125,7 @@ test('can write struct to buffer', function t(assert) {
 
 test('can write struct to buffer', function t(assert) {
     var result = thrift.Struct.toBufferResult(new thrift.Struct({number: 10}));
-    assert.deepEqual(result.value, new Buffer([
+    assert.deepEqual(result.value, (Buffer.from || Buffer)([
         0x08, // typeid:1 -- 8, i32
         0x00, 0x01, // id:2 -- 1, "number"
         0x00, 0x00, 0x00, 0x0a, // number:4 -- 10

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -18,10 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-/* global Buffer */
 /* eslint-disable max-len */
 'use strict';
 
+var Buffer = require('buffer').Buffer;
 var fs = require('fs');
 var path = require('path');
 var test = require('tape');

--- a/test/tmap.js
+++ b/test/tmap.js
@@ -34,13 +34,13 @@ var TPair = thriftrw.TPair;
 test('TMapRW', testRW.cases(TMapRW, [
 
     [TMap(11, 12, [
-        TPair(Buffer('key0'), TStruct([
+        TPair((Buffer.from || Buffer)('key0'), TStruct([
             TField(12, 1, TStruct([TField(8, 1, 20)])),
-            TField(12, 2, TStruct([TField(11, 1, Buffer('str2'))]))
+            TField(12, 2, TStruct([TField(11, 1, (Buffer.from || Buffer)('str2'))]))
         ])),
-        TPair(Buffer('key1'), TStruct([
+        TPair((Buffer.from || Buffer)('key1'), TStruct([
             TField(12, 1, TStruct([TField(8, 1, 10)])),
-            TField(12, 2, TStruct([TField(11, 1, Buffer('str1'))]))
+            TField(12, 2, TStruct([TField(11, 1, (Buffer.from || Buffer)('str1'))]))
         ]))
     ]), [
 

--- a/test/tstruct.js
+++ b/test/tstruct.js
@@ -38,7 +38,7 @@ test('TStructRW', testRW.cases(TStructRW, [
         0x00                    // type:1  -- stop
     ]],
 
-    [TStruct([TField(11, 1, Buffer('hello'))]), [
+    [TStruct([TField(11, 1, (Buffer.from || Buffer)('hello'))]), [
         0x0b,                   // type:1 -- string
         0x00, 0x01,             // id:2   -- 1
         0x00, 0x00, 0x00, 0x05, // len:4  -- 5
@@ -62,7 +62,7 @@ test('TStructRW', testRW.cases(TStructRW, [
 
     [TStruct([
         TField(12, 1, TStruct([TField(8, 1, 10)])),
-        TField(12, 2, TStruct([TField(11, 1, Buffer('hello'))]))
+        TField(12, 2, TStruct([TField(11, 1, (Buffer.from || Buffer)('hello'))]))
     ]), [
         0x0c,                   // type:1  -- struct
         0x00, 0x01,             // id:2    -- 1

--- a/test/unrecognized-exception.js
+++ b/test/unrecognized-exception.js
@@ -42,9 +42,9 @@ test('Exception RW', function t(assert) {
     err.byte = 0x00;
     err.i16 = 0x1234;
     err.i32 = 0x12345678;
-    err.i64 = Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+    err.i64 = (Buffer.from || Buffer)([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
     err.double = 1;
-    err.binary = Buffer('binary');
+    err.binary = (Buffer.from || Buffer)('binary');
     err.struct = {
         edges: {
             'abc': 1,


### PR DESCRIPTION
Node.js deprecated the overloaded Buffer constructor in favor of Buffer.from and Buffer.alloc.  This change introduces a convention that allows ThriftRW to continue using old patterns when run under old versions of Node.js, while avoiding the deprecation warnings on modern runtimes.

Avoid global Buffer lint directive. This is consistently elsewhere addressed by expressly importing the shimmable buffer module.