### PR TITLE
Polish async loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This change brings ThriftRW Node.js into parity.
   This affects the asynchronous filesystem API used by Thrift.load.
   readFile must accept an encoding argument.
+### Fixed
+- The `allowIncludeAlias` option previously only applied to the main Thrift module.
+  It now applies to all transitively included modules.
+  However, using this feature is ill-advised since no other Thrift
+  implementation has provided this experimental feature and it would limit
+  inter-language compatibility.
 
 ## [3.11.3] - 2018-10-04
 ### Changed


### PR DESCRIPTION
This change inlines the _init method into the Thrift constructor and pivots the async vs sync behavior from Thrift.load into the Thrift constructor, using a `callback` option which also replaces the signal `asyncReadFile` used previously to switch off the synchronous constructor behaviors.  V8 infers the final hidden classe produced by a constructor function from the properties created within the constructor function so inlining bypasses the creation of intermediate hidden classes.

Previous changes inferred that this project uses underscore prefixes for private methods, based on the precedent of compile/_compile.  This change corrects that misunderstanding by renaming some methods.